### PR TITLE
CDD-732 Add `uhd` cli + commands and scripts to login to aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,47 @@
 
 This repo contains the infrastructure to bootstrap our AWS accounts and deploy an instance of the UKHSA Dashboard app.
 
-## Getting started
+The tooling and scripts in this repo are tested with Linux and Mac. If you're using Windows these may work with WSL2 🤞.
+
+## Prerequisites
+
+Please make sure you have the following software installed:
+
+1. `aws` - `brew install awscli`
+
+## Configure AWS SSO
+
+Sign into AWS and configure your profiles:
 
 ```
-// TODO
+aws configure sso
+```
+
+Follow the prompts and configure the accounts / roles with the following profile names. When prompted for the region, enter `eu-west-2`.
+
+| Account     | Role          | Profile Name      |
+| ----------- | ------------- | ----------------- |
+| Development | Administrator | `uhd-dev:admin`   |
+| Tooling     | Administrator | `uhd-tools:admin` |
+
+## Getting started
+
+Source our CLI tool:
+
+```
+source uhd.sh
+```
+
+Assume the admin role in our `dev` account:
+
+```
+uhd aws login uhd-dev:admin
+```
+
+And then test that you can query S3:
+
+```
+aws s3 ls
 ```
 
 ## Related repos

--- a/scripts/_aws.sh
+++ b/scripts/_aws.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+
+function _aws_help() {
+    echo
+    echo "uhd aws <command> [options]"
+    echo
+    echo "commands:"
+    echo "  help            - this help screen"
+    echo
+    echo "  login <profile> - login and assume the configured role"
+    echo
+
+    return 1
+}
+
+function _aws() {
+    local verb=$1
+    local args=(${@:2})
+
+    case $verb in
+        "login") _aws_login $args ;;
+
+        *) _aws_help ;;
+    esac
+}
+
+function _aws_login() {
+    local profile_name=$1
+    if [[ -z ${profile_name} ]]; then
+        echo "Profile name is required." >&2
+        return 1
+    fi
+
+    aws sso login --profile $profile_name
+
+    export AWS_PROFILE=$profile_name
+}

--- a/uhd.sh
+++ b/uhd.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+
+for script_file in "$root"/scripts/*.sh; do
+    source $script_file
+done
+
+function _uhd_commands_help() {
+    echo
+    echo UKHSA Dashboard CLI Tool 
+    echo
+    echo "uhd <command> [options]"
+    echo
+    echo "commands:"
+    echo "  help        - this help screen"
+    echo
+    echo "  aws         - aws commands"
+    echo
+
+    return 1
+}
+
+function uhd() {
+    if [ "$RUNNING_IN_CI" = "1" ]; then
+        echo $0 $@
+    fi
+
+    local current=$(pwd)
+    local command=$1
+
+    cd $root
+
+    case $command in
+        "aws") _aws "${@:2}" ;;
+
+        *) _uhd_commands_help ;;
+    esac
+
+    cd $current
+}
+
+echo "Usage: uhd"


### PR DESCRIPTION
The PR adds the beginning of our CLI. 

Implemented so far are:

- Instructions on how to configure the AWS cli
- A comand to login to AWS and assume a pre-configured role