### PR TITLE
CDD-755 Adding a vpc

### DIFF
--- a/terraform/20-app/etc/dev.tfvars
+++ b/terraform/20-app/etc/dev.tfvars
@@ -1,0 +1,1 @@
+environment_type="dev"

--- a/terraform/20-app/etc/prod.tfvars
+++ b/terraform/20-app/etc/prod.tfvars
@@ -1,0 +1,1 @@
+environment_type="prod"

--- a/terraform/20-app/etc/test.tfvars
+++ b/terraform/20-app/etc/test.tfvars
@@ -1,0 +1,1 @@
+environment_type="test"

--- a/terraform/20-app/etc/uat.tfvars
+++ b/terraform/20-app/etc/uat.tfvars
@@ -1,0 +1,1 @@
+environment_type="uat"

--- a/terraform/20-app/vars.tf
+++ b/terraform/20-app/vars.tf
@@ -5,3 +5,5 @@ variable "assume_account_id" {
 variable "assume_role_name" {
   default = "terraform"
 }
+
+variable "environment_type" { }

--- a/terraform/20-app/vpc.tf
+++ b/terraform/20-app/vpc.tf
@@ -1,7 +1,17 @@
-resource "aws_vpc" "main" {
-    cidr_block = "10.0.0.0/16"
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
 
-    tags = {
-        Name = "${local.prefix}-main"
-    }
+  name = "${local.prefix}-main"
+  cidr = "10.0.0.0/16"
+
+  azs               = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
+  database_subnets  = ["10.0.201.0/24", "10.0.202.0/24", "10.0.203.0/24"]
+  private_subnets   = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets    = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  create_database_subnet_route_table     = var.environment_type == "dev"
+  create_database_internet_gateway_route = var.environment_type == "dev"
+
+  enable_dns_hostnames = var.environment_type == "dev"
+  enable_dns_support   = var.environment_type == "dev"
 }


### PR DESCRIPTION
This PR lays down an initial VPC.  We have 3 types of subnet, and spread them over 3 AZs:

- public => for the LD endpoints
- private => for all our containers 
- db => for RDS instances

I've also enabled public access to the DB subnets for dev envs.

@A-Ashiq any thoughts on IP ranges for the subnets?  we have 255 IPs in each which seems like a sensible place to start?