### PR TITLE
CDD-799 Turn on dependabot version updates for terraform

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "terraform"
+    directory: "/terraform/10-account"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform/20-app"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Turns on dependabot for automated dependency updates.  We should do this in the other repos too