### PR TITLE
Set `health_check` for frontend to `/api/health` instead of the base route `/`

### DIFF
--- a/terraform/20-app/alb.front-end.tf
+++ b/terraform/20-app/alb.front-end.tf
@@ -19,7 +19,7 @@ module "front_end_alb" {
       health_check = {
         enabled             = true
         interval            = 30
-        path                = "/"
+        path                = "/api/health"
         port                = "traffic-port"
         healthy_threshold   = 3
         unhealthy_threshold = 3


### PR DESCRIPTION
Previously the load balancer was probing the front end by sending a request to the `/` route.

Our current next.js server has a revalidate time of 60s. Which means anyone visiting the site/a request being sent to a route would trigger the cache to be refreshed.
This meant that the next.js server was purging and rehydrating its cache everytime the load balancer was conducting its health probe. Which in turn meant we were spamming the API + DB.

This PR updates the load balancer for the frontend to a new route `/api/health` which is a bespoke endpoint on the frontend which will just naively returns a 200 without triggering any of next.js revalidate cache logic