### PR TITLE
CDD-993 Bump postgres to the latest

### DIFF
--- a/terraform/20-app/vars.tf
+++ b/terraform/20-app/vars.tf
@@ -17,7 +17,7 @@ variable "rds_app_db_engine" {
 }
 
 variable "rds_app_db_engine_version" {
-  default = "14.8"
+  default = "15.3"
 }
 
 variable "tools_account_id" {


### PR DESCRIPTION
Can't merge until 20th July, as we need to wait for all the existing instances to be upgraded first.