### PR TITLE
SPIKE: SSR in the front end with cloud front in front

### DIFF
--- a/terraform/20-app/alb.front-end.tf
+++ b/terraform/20-app/alb.front-end.tf
@@ -40,7 +40,7 @@ module "front_end_alb" {
 }
 
 module "front_end_alb_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
   version = "5.1.0"
 
   name   = "${local.prefix}-front-end-alb"
@@ -50,9 +50,7 @@ module "front_end_alb_security_group" {
     {
       description = "http from allowed ips"
       rule        = "http-80-tcp"
-      cidr_blocks = join(",", local.ip_allow_list.engineers,
-        local.ip_allow_list.project_team,
-      local.ip_allow_list.other_stakeholders)
+      cidr_blocks = "0.0.0.0/0"
     }
   ]
 

--- a/terraform/20-app/cloud-front.front-end.tf
+++ b/terraform/20-app/cloud-front.front-end.tf
@@ -1,0 +1,31 @@
+module "cloudfront_front_end" {
+  source  = "terraform-aws-modules/cloudfront/aws"
+  version = "3.2.1"
+
+  comment             = "${local.prefix}-front-end"
+  wait_for_deployment = false
+
+  origin = {
+    front_end = {
+      domain_name = module.front_end_alb.lb_dns_name
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "match-viewer"
+        origin_ssl_protocols   = ["TLSv1.2"]
+      }
+    }
+  }
+
+  default_cache_behavior = {
+    target_origin_id       = "front_end"
+    viewer_protocol_policy = "allow-all"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    query_string           = true
+
+    # This is id for SecurityHeadersPolicy copied from https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html
+    response_headers_policy_id = "67f7725c-6f97-4210-82d7-5512b31e9d03"
+  }
+}

--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -18,7 +18,7 @@ module "ecs_service_front_end" {
       memory                   = 1024
       essential                = true
       readonly_root_filesystem = false
-      image                    = "${module.ecr_front_end.repository_url}:latest"
+      image                    = "${module.ecr_front_end.repository_url}:ssr"
       port_mappings = [
         {
           containerPort = 3000


### PR DESCRIPTION
This is a spike.  **DO NOT** merge! 💣

In this branch so far, we have:

- FE tasks updated to use a new image with the `ssr` tag.  You'll need to build this locally and push to your ECR.
- IP restrictions turned off on front end load balancer 😬, to allow cloud front to fetch content from the origin (this seems to not be working)
- could front distribution created for front end, and configured with the FE load balancer as it's origin


This all should work, but when I tried it all i got was 504 errors in cloud front.

TODO:
- fix connectivity between CF and origin LB
- see how long it takes to fill the CF cache 
- check for cache hit /  miss when browsing site
- invalidate some objects in cache and see how long it takes to refresh (to simulate us flushing the cache when a content change is made)