### PR TITLE
Apply IP allowlist to application load balancer in front of public API

### DIFF
--- a/terraform/20-app/alb.public_api.tf
+++ b/terraform/20-app/alb.public_api.tf
@@ -48,9 +48,14 @@ module "public_api_alb_security_group" {
 
   ingress_with_cidr_blocks = [
     {
-      description = "http from internet"
+      description = "http from allowed ips"
       rule        = "http-80-tcp"
-      cidr_blocks = "0.0.0.0/0"
+      cidr_blocks = join(",",
+        local.ip_allow_list.engineers,
+        local.ip_allow_list.project_team,
+        local.ip_allow_list.other_stakeholders,
+        local.ip_allow_list.user_testing_participants
+      )
     }
   ]
 


### PR DESCRIPTION
I'm going to remove the `APIKey` from the public API so this PR will move the public API back behind the IP allowlist in the meantime 