### PR TITLE
Task/disconnect feedback api from rds/cdd 1300

### DIFF
--- a/terraform/20-app/ecs.service.feedback-api.tf
+++ b/terraform/20-app/ecs.service.feedback-api.tf
@@ -94,12 +94,4 @@ module "feedback_api_tasks_security_group_rules" {
       cidr_blocks = "0.0.0.0/0"
     },
   ]
-
-  egress_with_source_security_group_id = [
-    {
-      description              = "lb to db"
-      rule                     = "postgresql-tcp"
-      source_security_group_id = module.app_rds_security_group.security_group_id
-    }
-  ]
 }

--- a/terraform/20-app/rds.tf
+++ b/terraform/20-app/rds.tf
@@ -47,11 +47,6 @@ module "app_rds_security_group" {
       description              = "cms admin tasks to db"
       rule                     = "postgresql-tcp"
       source_security_group_id = module.ecs_service_cms_admin.security_group_id
-    },
-    {
-      description              = "feedback api tasks to db"
-      rule                     = "postgresql-tcp"
-      source_security_group_id = module.ecs_service_feedback_api.security_group_id
-    },
+    }
   ]
 }


### PR DESCRIPTION
This PR does the following:

- Removes the postgres credentials from the feedback API
- Disconnects RDS from the feedback API as it does not need access to it

Notes:

This is now possible because the API key is enforced at the load balancer of the feedback API.
The feedback API does not currently need to read/write from the RDS instance hence it can run freely in standalone mode