### PR TITLE
Task/public api crawler/cdd 1284

### DIFF
--- a/terraform/20-app/ecs-jobs/hydrate-public-api-cache.tftpl
+++ b/terraform/20-app/ecs-jobs/hydrate-public-api-cache.tftpl
@@ -17,7 +17,7 @@
         "command": ["scripts/hydrate_public_api_cache.sh"],
         "environment": [
             {"name": "PUBLIC_API_URL", "value": "${public_api_url}"},
-            {"name": "API_KEY", "value": ${api_key}}
+            {"name": "CDN_AUTH_KEY", "value": ${cdn_auth_key}}
         ]
       }
     ]

--- a/terraform/20-app/ecs.jobs.hydrate-public-api-cache.tf
+++ b/terraform/20-app/ecs.jobs.hydrate-public-api-cache.tf
@@ -2,7 +2,7 @@ resource "local_sensitive_file" "ecs_job_hydrate_public_api_cache" {
   filename = "ecs-jobs/hydrate-public-api-cache.json"
   content  = templatefile("ecs-jobs/hydrate-public-api-cache.tftpl", {
     public_api_url    = local.urls.public_api
-    api_key           = jsonencode(aws_secretsmanager_secret_version.cdn_public_api_secure_header_value.secret_string)
+    cdn_auth_key      = jsonencode(aws_secretsmanager_secret_version.cdn_public_api_secure_header_value.secret_string)
     cluster_arn       = module.ecs.cluster_arn
     security_group_id = module.ecs_service_public_api.security_group_id
     subnet_ids        = module.vpc.private_subnets


### PR DESCRIPTION
This PR does the following:

- Sets up a `hydrate-public-api-cache` ECS job 


Notes:
There are some issues around IPs. Right now Cloudfront for prod does not have an allow list, which means this job can be ran without any further changes.
The issue is we still have the ip allow list for all the other envs, so the job will run on an instance which emanates from the nat gateway. This is not currently on the IP allow list and therefore the job will be blocked from making requests for all non-prod envs.
In the interest of getting this in for prod (and cause I need to move on). I'm submitting the PR as is. I'll follow up with something to see what we can do about non-prod envs 