### PR TITLE
task/adjust-app-mode-env-var-of-ingestion-ecs-job/CDD-1504

### DIFF
--- a/terraform/20-app/ecs.service.ingestion.tf
+++ b/terraform/20-app/ecs.service.ingestion.tf
@@ -72,10 +72,6 @@ module "ecs_service_ingestion" {
       ]
       environment = [
         {
-          name  = "APP_MODE"
-          value = "INGESTION"
-        },
-        {
           name  = "INGESTION_BUCKET_NAME"
           value = module.s3_ingest.s3_bucket_id
         },


### PR DESCRIPTION
This PR removes the `APP_MODE` from being set as `INGESTION` for the ECS ingestion job.
Under the hood there are some extra configurations happening with things like fetching the postgres password from secrets manager. So as to not break anything in the interim, I've opted to remove this env var from being set for the ingestion job.

We probably need to think about what we want to do with this ingestion service. For its primary use it's not really needed once the data streaming pipeline comes into play. But we do still use this job for the initial seeding of environments `bootstrap-env` job. Perhaps even just a rename of this service might suffice?

Note that we will also want to remove the `upload-files-from-s3` ecs job. Since that will be deprecated by the data streaming pipeline