### PR TITLE
Delete terraform workspace after resources within the workspace have been destroyed

### DIFF
--- a/scripts/_terraform.sh
+++ b/scripts/_terraform.sh
@@ -298,7 +298,7 @@ function _terraform_destroy_layer() {
         -var "assume_account_id=${assume_account_id}" \
         -var "tools_account_id=${tools_account_id}" \
         -var-file=$var_file \
-        -auto-approve
+        -auto-approve || return 1
 
     _terraform_delete_workspace $workspace || return 1
 }


### PR DESCRIPTION
Note that this won’t clean up all the empty workspaces for all the CI runs, but it should clean up any more that are done from now on.
More than likekly we'll have to purge the pool of existing empty workspaces we have another way