### PR TITLE
Add GOOGLE_TAG_MANAGER_ID env var

### DIFF
--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -42,6 +42,10 @@ module "ecs_service_front_end" {
           value = local.urls.public_api
         },
         {
+          name  = "GOOGLE_TAG_MANAGER_ID"
+          value = "GTM-W39KF5J2"
+        },
+        {
           name  = "NEXT_REVALIDATE_TIME"
           value = "360"
         }


### PR DESCRIPTION
- Adds a new environment variable for the GTM FE migration work in [CDD-1353](https://digitaltools.phe.org.uk/browse/CDD-1353)