### PR TITLE
Add unleash feature flags application

### DIFF
--- a/scripts/_secrets.sh
+++ b/scripts/_secrets.sh
@@ -51,7 +51,10 @@ function _delete_all_secrets() {
                 "uhd-${env}-cdn-front-end-secure-header-value"
                 "uhd-${env}-cdn-public-api-secure-header-value"
                 "uhd-${env}-private-api-email-credentials"
-                "uhd-${env}-google-analytics-credentials")
+                "uhd-${env}-google-analytics-credentials"
+                "uhd-${env}-aurora-db-feature-flags-credentials"
+                "uhd-${env}-feature-flags-admin-user-credentials"
+                "uhd-${env}-feature-flags-api-keys")
 
     for ((i=1; i<=${#secret_ids[@]}; ++i)); do
         _delete_secret "${secret_ids[i]}"

--- a/terraform/10-account/.terraform.lock.hcl
+++ b/terraform/10-account/.terraform.lock.hcl
@@ -2,67 +2,71 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.40.0"
-  constraints = ">= 2.49.0, >= 3.72.0, >= 3.74.0, >= 4.0.0, >= 4.36.0, >= 4.40.0, >= 4.63.0, >= 5.0.0, >= 5.27.0, 5.40.0"
+  version     = "5.41.0"
+  constraints = ">= 2.49.0, >= 3.72.0, >= 3.74.0, >= 4.0.0, >= 4.36.0, >= 4.40.0, >= 4.63.0, >= 5.0.0, >= 5.27.0, 5.41.0"
   hashes = [
-    "h1:KEqMoJwLw6Z9bTO4K8nPVvQQa6YiM+bvz89Sw7tNFJw=",
-    "h1:mLZbhNUyXQTWQXOCoHglI10XwcvqGqvnn21juy/Jk68=",
-    "h1:vnFdR2OxkoCLwmyi1DmuAoM+fdqW3g66Hx7mYsR6b1E=",
-    "zh:11f177a2385703740bd26d0652d3dba08575101d7639f386ce5637bdb0e29a13",
-    "zh:203fc43e69634f1bd487a9dc24b01944dfd568beac78e491f26677d103d343ed",
-    "zh:3697ebad4929da30ea98276a85d4ce5ebfc48508f4dd149e17e1dcdc7f306c6e",
-    "zh:421e0799756587e728f75a9024b8d4e38707cd6d65cf0710cb8d189062c85a58",
-    "zh:4be2adcd4c32a66159c532908f0d425d793c814b3686832e9af549b1515ae032",
-    "zh:55778b32470212ce6bbfd402529c88e7ea6ba34b0882f85d6ea001ff5c6255a5",
-    "zh:689a4c1fd1e1d5dab7b169759389c76f25e366f19a470971674321d6fca09791",
-    "zh:68a23eda608573a053e8738894457bd0c11766bc243e68826c78ab6b5a144710",
+    "h1:DiX7N35G2NUQRyRGy90+gyePnhP4w77f8LrJUronotE=",
+    "h1:SgIWBDBA1uNB/Y7CaLFeNX/Ju2xboSSQmRv35Vbi46M=",
+    "h1:uNln7837/ZTVgQBk+hhfgB9Y87icES6X0lMSOfK5c7g=",
+    "zh:0553331a6287c146353b6daf6f71987d8c000f407b5e29d6e004ea88faec2e67",
+    "zh:1a11118984bb2950e8ee7ef17b0f91fc9eb4a42c8e7a9cafd7eb4aca771d06e4",
+    "zh:236fedd266d152a8233a7fe27ffdd99ca27d9e66a9618a988a4c3da1ac24a33f",
+    "zh:34bc482ea04cf30d4d216afa55eecf66854e1acf93892cb28a6b5af91d43c9b7",
+    "zh:39d7eb15832fe339bf46e3bab9852280762a1817bf1afc459eecd430e20e3ad5",
+    "zh:39fb07429c51556b05170ec2b6bd55e2487adfe1606761eaf1f2a43c4bb20e47",
+    "zh:71d7cd3013e2f3fa0f65194af29ee6f5fa905e0df2b72b723761dc953f4512ea",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a1580115c22564e5752e569dc40482503de6cced44da3e9431885cd9d4bf18ea",
-    "zh:b127756d7ee513691e76c211570580c10eaa2f7a7e4fd27c3566a48ec214991c",
-    "zh:b7ccea7a759940c8dcf8726272eed6653eed0b31f7223f71e829a344627afd39",
-    "zh:bb130fc50494fd45406e04b44d242da9a8f138a4a43feb65cf9e86d13aa13629",
-    "zh:cf1c972c90d5f22c9705274a33792275e284a0a3fcac12ce4083b5a4480463f4",
-    "zh:ebe60d3887b23703ca6a4c65b15c6d7b8d93ba27a028d996d17882fe6e98d5c0",
+    "zh:9b271ae12394e7e2ce6da568b42226a146e90fd705e02a670fcb93618c4aa19f",
+    "zh:a884dd978859d001709681f9513ba0fbb0753d1d459a7f3434ecc5f1b8699c49",
+    "zh:b8c3c7dc10ae4f6143168042dcf8dee63527b103cc37abc238ea06150af38b6e",
+    "zh:ba94ffe0893ad60c0b70c402e163b4df2cf417e93474a9cc1a37535bba18f22d",
+    "zh:d5ba851d971ff8d796afd9a100acf55eaac0c197c6ab779787797ce66f419f0e",
+    "zh:e8c090d0c4f730c4a610dc4f0c22b177a0376d6f78679fc3f1d557b469e656f4",
+    "zh:ed7623acde26834672969dcb5befdb62900d9f216d32e7478a095d2b040a0ea7",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/external" {
-  version     = "2.3.2"
+  version     = "2.3.3"
   constraints = ">= 1.0.0"
   hashes = [
-    "h1:cy50n4q+Ir4GYppAfuYhQbBJVxMZbJUlIvM6FVK2axs=",
-    "zh:020bf652739ecd841d696e6c1b85ce7dd803e9177136df8fb03aa08b87365389",
-    "zh:0c7ea5a1cbf2e01a8627b8a84df69c93683f39fe947b288e958e72b9d12a827f",
-    "zh:25a68604c7d6aa736d6e99225051279eaac3a7cf4cab33b00ff7eae7096166f6",
-    "zh:34f46d82ca34604f6522de3b36eda19b7ad3be1e38947afc6ac31656eab58c8a",
-    "zh:6959f8f2f3de93e61e0abb90dbec41e28a66daec1607c46f43976bd6da50bcfd",
+    "h1:H+3QlVPs/7CDa3I4KU/a23wYeGeJxeBlgvR7bfK1t1w=",
+    "h1:Qi72kOSrEYgEt5itloFhDfmiFZ7wnRy3+F74XsRuUOw=",
+    "h1:gShzO1rJtADK9tDZMvMgjciVAzsBh39LNjtThCwX1Hg=",
+    "zh:03d81462f9578ec91ce8e26f887e34151eda0e100f57e9772dbea86363588239",
+    "zh:37ec2a20f6a3ec3a0fd95d3f3de26da6cb9534b30488bc45723e118a0911c0d8",
+    "zh:4eb5b119179539f2749ce9de0e1b9629d025990f062f4f4dddc161562bb89d37",
+    "zh:5a31bb58414f41bee5e09b939012df5b88654120b0238a89dfd6691ba197619a",
+    "zh:6221a05e52a6a2d4f520ffe7cbc741f4f6080e0855061b0ed54e8be4a84eb9b7",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:a81e5d65a343da9caa6f1d17ae0aced9faecb36b4f8554bd445dbd4f8be21ab6",
-    "zh:b1d3f1557214d652c9120862ce27e9a7b61cb5aec5537a28240a5a37bf0b1413",
-    "zh:b71588d006471ae2d4a7eca2c51d69fd7c5dec9b088315599b794e2ad0cc5e90",
-    "zh:cfdaae4028b644dff3530c77b49d31f7e6f4c4e2a9e5c8ac6a88e383c80c9e9c",
-    "zh:dbde15154c2eb38a5f54d0e7646bc67510004179696f3cc2bc1d877cecacf83b",
-    "zh:fb681b363f83fb5f64dfa6afbf32d100d0facd2a766cf3493b8ddb0398e1b0f7",
+    "zh:8bb068496b4679bef625e4710d9f3432e301c3a56602271f04e60eadf7f8a94c",
+    "zh:94742aa5378bab626ce34f79bcef6a373e4f86ea7a8b762e9f71270a899e0d00",
+    "zh:a485831b5a525cd8f40e8982fa37da40ff70b1ae092c8b755fcde123f0b1238d",
+    "zh:a647ff16d071eabcabd87ea8183eb90a775a0294ddd735d742075d62fff09193",
+    "zh:b74710c5954aaa3faf262c18d36a8c2407862d9f842c63e7fa92fa4de3d29df6",
+    "zh:fa73d83edc92af2e551857594c2232ba6a9e3603ad34b0a5940865202c08d8d7",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/local" {
-  version     = "2.4.1"
+  version     = "2.5.1"
   constraints = ">= 1.0.0"
   hashes = [
-    "h1:gpp25uNkYJYzJVnkyRr7RIBVfwLs9GSq2HNnFpTRBg0=",
-    "zh:244b445bf34ddbd167731cc6c6b95bbed231dc4493f8cc34bd6850cfe1f78528",
-    "zh:3c330bdb626123228a0d1b1daa6c741b4d5d484ab1c7ae5d2f48d4c9885cc5e9",
-    "zh:5ff5f9b791ddd7557e815449173f2db38d338e674d2d91800ac6e6d808de1d1d",
-    "zh:70206147104f4bf26ae67d730c995772f85bf23e28c2c2e7612c74f4dae3c46f",
-    "zh:75029676993accd6bef933c196b2fad51a9ec8a69a847dbbe96ec8ebf7926cdc",
+    "h1:/GAVA/xheGQcbOZEq0qxANOg+KVLCA7Wv8qluxhTjhU=",
+    "h1:8oTPe2VUL6E2d3OcrvqyjI4Nn/Y/UEQN26WLk5O/B0g=",
+    "h1:tjcGlQAFA0kmQ4vKkIPPUC4it1UYxLbg4YvHOWRAJHA=",
+    "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
+    "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
+    "zh:196bfb49086f22fd4db46033e01655b0e5e036a5582d250412cc690fa7995de5",
+    "zh:37c92ec084d059d37d6cffdb683ccf68e3a5f8d2eb69dd73c8e43ad003ef8d24",
+    "zh:4269f01a98513651ad66763c16b268f4c2da76cc892ccfd54b401fff6cc11667",
+    "zh:51904350b9c728f963eef0c28f1d43e73d010333133eb7f30999a8fb6a0cc3d8",
+    "zh:73a66611359b83d0c3fcba2984610273f7954002febb8a57242bbb86d967b635",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7d48d5999fe1fcdae9295a7c3448ac1541f5a24c474bd82df6d4fa3732483f2b",
-    "zh:b766b38b027f0f84028244d1c2f990431a37d4fc3ac645962924554016507e77",
-    "zh:bfc7ad301dada204cf51c59d8bd6a9a87de5fddb42190b4d6ba157d6e08a1f10",
-    "zh:c902b527702a8c5e2c25a6637d07bbb1690cb6c1e63917a5f6dc460efd18d43f",
-    "zh:d68ae0e1070cf429c46586bc87580c3ed113f76241da2b6e4f1a8348126b3c46",
-    "zh:f4903fd89f7c92a346ae9e666c2d0b6884c4474ae109e9b4bd15e7efaa4bfc29",
+    "zh:7ae387993a92bcc379063229b3cce8af7eaf082dd9306598fcd42352994d2de0",
+    "zh:9e0f365f807b088646db6e4a8d4b188129d9ebdbcf2568c8ab33bddd1b82c867",
+    "zh:b5263acbd8ae51c9cbffa79743fbcadcb7908057c87eb22fd9048268056efbc4",
+    "zh:dfcd88ac5f13c0d04e24be00b686d069b4879cc4add1b7b1a8ae545783d97520",
   ]
 }
 
@@ -71,6 +75,8 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 2.0.0"
   hashes = [
     "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
     "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
     "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",

--- a/terraform/10-account/.terraform.lock.hcl
+++ b/terraform/10-account/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.41.0"
-  constraints = ">= 2.49.0, >= 3.72.0, >= 3.74.0, >= 4.0.0, >= 4.36.0, >= 4.40.0, >= 4.63.0, >= 5.0.0, >= 5.27.0, 5.41.0"
+  constraints = ">= 2.49.0, >= 3.74.0, >= 4.0.0, >= 4.33.0, >= 4.36.0, >= 4.40.0, >= 4.63.0, >= 5.0.0, >= 5.27.0, 5.41.0"
   hashes = [
     "h1:DiX7N35G2NUQRyRGy90+gyePnhP4w77f8LrJUronotE=",
     "h1:SgIWBDBA1uNB/Y7CaLFeNX/Ju2xboSSQmRv35Vbi46M=",

--- a/terraform/10-account/versions.tf
+++ b/terraform/10-account/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.40.0"
+      version = "5.41.0"
     }
   }
   required_version = ">= 1.4.5"

--- a/terraform/20-app/.terraform.lock.hcl
+++ b/terraform/20-app/.terraform.lock.hcl
@@ -2,27 +2,27 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.41.0"
-  constraints = ">= 2.49.0, >= 3.29.0, >= 3.74.0, >= 4.22.0, >= 4.29.0, >= 4.33.0, >= 4.59.0, >= 4.63.0, >= 4.66.1, >= 5.0.0, >= 5.27.0, 5.41.0"
+  version     = "5.42.0"
+  constraints = ">= 2.49.0, >= 3.29.0, >= 3.74.0, >= 4.22.0, >= 4.33.0, >= 4.55.0, >= 4.59.0, >= 4.66.1, >= 5.0.0, >= 5.12.0, >= 5.27.0, >= 5.32.0, >= 5.42.0, 5.42.0"
   hashes = [
-    "h1:DiX7N35G2NUQRyRGy90+gyePnhP4w77f8LrJUronotE=",
-    "h1:SgIWBDBA1uNB/Y7CaLFeNX/Ju2xboSSQmRv35Vbi46M=",
-    "h1:uNln7837/ZTVgQBk+hhfgB9Y87icES6X0lMSOfK5c7g=",
-    "zh:0553331a6287c146353b6daf6f71987d8c000f407b5e29d6e004ea88faec2e67",
-    "zh:1a11118984bb2950e8ee7ef17b0f91fc9eb4a42c8e7a9cafd7eb4aca771d06e4",
-    "zh:236fedd266d152a8233a7fe27ffdd99ca27d9e66a9618a988a4c3da1ac24a33f",
-    "zh:34bc482ea04cf30d4d216afa55eecf66854e1acf93892cb28a6b5af91d43c9b7",
-    "zh:39d7eb15832fe339bf46e3bab9852280762a1817bf1afc459eecd430e20e3ad5",
-    "zh:39fb07429c51556b05170ec2b6bd55e2487adfe1606761eaf1f2a43c4bb20e47",
-    "zh:71d7cd3013e2f3fa0f65194af29ee6f5fa905e0df2b72b723761dc953f4512ea",
+    "h1:0lkSSlK45Qil9fO1kFy8RXVC/k6qfC4LDZIaCKnWcUc=",
+    "h1:Gwe5HXZYD/3M5j6LwKhp8amb1SraCR9p+G96d381RVc=",
+    "h1:Yxsj34z606m8wssYDHyleuBlQ9i+94MHwRs38thQPZU=",
+    "zh:0fb12bd56a3ad777b29f957c56dd2119776dbc01b6074458f597990e368c82de",
+    "zh:16e99c13bef6e3777f67c240c916f57c01c9c142254cfb2720e08281ff906447",
+    "zh:218268f5fe73bcb19e9a996f781ab66df0da9e333d1c60612e3c51ad28a5105f",
+    "zh:220b17f7053d11548f35136669687d30ef1f1036e15393275325fd2b9654c715",
+    "zh:2256cfd74988ce05eada76b42efffc6fe2bf4d60b61f57e4db4fcf65ced4c666",
+    "zh:52da19f531e0cb9828f73bca620e30264e63a494bd7f9ce826aabcf010d3a241",
+    "zh:56069ce08d720280ba39aaf2fdd40c4357ffb54262c80e4d39c4e540a38e76af",
+    "zh:82c81398e68324029167f813fbb7c54fa3d233e99fa05001d85cbce8bdd08bb3",
+    "zh:82d6eaa87f5ab318959064e6c89adc2baabaf70b13f2f7de866f62416de05352",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:9b271ae12394e7e2ce6da568b42226a146e90fd705e02a670fcb93618c4aa19f",
-    "zh:a884dd978859d001709681f9513ba0fbb0753d1d459a7f3434ecc5f1b8699c49",
-    "zh:b8c3c7dc10ae4f6143168042dcf8dee63527b103cc37abc238ea06150af38b6e",
-    "zh:ba94ffe0893ad60c0b70c402e163b4df2cf417e93474a9cc1a37535bba18f22d",
-    "zh:d5ba851d971ff8d796afd9a100acf55eaac0c197c6ab779787797ce66f419f0e",
-    "zh:e8c090d0c4f730c4a610dc4f0c22b177a0376d6f78679fc3f1d557b469e656f4",
-    "zh:ed7623acde26834672969dcb5befdb62900d9f216d32e7478a095d2b040a0ea7",
+    "zh:ade8490cfdd8de8b9a82986588595b67e0ad1048d9e2d3a6f5164320179c2cd0",
+    "zh:b094ef56ae9bfffd586f46d4f7fb0097798738df758a8f3c51578ee163495c7e",
+    "zh:bd5e68e1e454bae0f8d73cff8448e814a35855a561c33b745e1b8b525fb06c9f",
+    "zh:c111c6a854bf121facca1642d528bfa80fb4214554ac6c33e4a59c86bc605b71",
+    "zh:e04df69a557adbcdf8efc77eb45be748f0acbe800ccede1e0895393c87722a0f",
   ]
 }
 

--- a/terraform/20-app/.terraform.lock.hcl
+++ b/terraform/20-app/.terraform.lock.hcl
@@ -2,53 +2,55 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.32.1"
-  constraints = ">= 2.49.0, >= 3.29.0, >= 3.72.0, >= 3.74.0, >= 4.9.0, >= 4.22.0, >= 4.29.0, >= 4.55.0, >= 4.59.0, >= 4.63.0, >= 5.0.0, 5.32.1"
+  version     = "5.41.0"
+  constraints = ">= 2.49.0, >= 3.29.0, >= 3.74.0, >= 4.22.0, >= 4.29.0, >= 4.33.0, >= 4.59.0, >= 4.63.0, >= 4.66.1, >= 5.0.0, >= 5.27.0, 5.41.0"
   hashes = [
-    "h1:QABqkHM6/fMi9RGbAzTx0/gy+6tDl2RYsVn5YGtKa90=",
-    "h1:VMmGHDV8nrn1YITcB5PH7/+bgAdoyNJqjyiRpGp3Rhw=",
-    "h1:jv1eeMPObgcJOEV6x9BmT1rSUDZ5cX0FBpweCNu4bnc=",
-    "zh:0c603e0ea9ec481f1588ca44d3464fe43ed936a8452e0c70d347c8e71a1b19a4",
-    "zh:0d43c845330ea4aaa152caf35819069215fcf17e4468b9d94c631f7d4178b1ac",
-    "zh:1211275208e8142bfa27987fdeb3eae40075ff569bf198330975f470bc4f5137",
-    "zh:1d8e7e4a2ff45a8b56037d030e2978fc04007941f62f1e265e251801a1d0c3cc",
-    "zh:4f6a8a6c9413b8b9267673cb7fb9dee7dc81946f7cc17d23e2104304f4ec4472",
-    "zh:6d769c74f8157260a37a32a1036b77f9795e21df2df7cadf4c7acc85b2dfd96e",
-    "zh:778fd9bf80424a62ebf5f059dcabfc4a588b0791ba18c1cf727bbdc1aed40351",
-    "zh:7bf1b063065bbe39b71e2a5895915fcbcc0cf7f553f84388e81888506d292fce",
+    "h1:DiX7N35G2NUQRyRGy90+gyePnhP4w77f8LrJUronotE=",
+    "h1:SgIWBDBA1uNB/Y7CaLFeNX/Ju2xboSSQmRv35Vbi46M=",
+    "h1:uNln7837/ZTVgQBk+hhfgB9Y87icES6X0lMSOfK5c7g=",
+    "zh:0553331a6287c146353b6daf6f71987d8c000f407b5e29d6e004ea88faec2e67",
+    "zh:1a11118984bb2950e8ee7ef17b0f91fc9eb4a42c8e7a9cafd7eb4aca771d06e4",
+    "zh:236fedd266d152a8233a7fe27ffdd99ca27d9e66a9618a988a4c3da1ac24a33f",
+    "zh:34bc482ea04cf30d4d216afa55eecf66854e1acf93892cb28a6b5af91d43c9b7",
+    "zh:39d7eb15832fe339bf46e3bab9852280762a1817bf1afc459eecd430e20e3ad5",
+    "zh:39fb07429c51556b05170ec2b6bd55e2487adfe1606761eaf1f2a43c4bb20e47",
+    "zh:71d7cd3013e2f3fa0f65194af29ee6f5fa905e0df2b72b723761dc953f4512ea",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b57506c3f46e850543fc1ee9522f231311e8540730db76bbf7a3f4d81777a4bd",
-    "zh:d37c8655b2a31435a116a1af7031f2bcdecf4c7e7e74903b88203798fb39043e",
-    "zh:db369802896eb10bbfed00bf3bd568b35fb5d903d3624d555b6574c5c4e2d94e",
-    "zh:e9992bfccf8205c495aebb7da917404496f96b5d3ea4a915a8884994ca8d860c",
-    "zh:ed1e0ef83cde313f1ccb3e18fc9dc63bf6ca473ec07554df5e24c706708a6866",
-    "zh:f0d19ed41352da9be308dff72899ecf5af7a42b592cf37fb98e9064e7622d35e",
+    "zh:9b271ae12394e7e2ce6da568b42226a146e90fd705e02a670fcb93618c4aa19f",
+    "zh:a884dd978859d001709681f9513ba0fbb0753d1d459a7f3434ecc5f1b8699c49",
+    "zh:b8c3c7dc10ae4f6143168042dcf8dee63527b103cc37abc238ea06150af38b6e",
+    "zh:ba94ffe0893ad60c0b70c402e163b4df2cf417e93474a9cc1a37535bba18f22d",
+    "zh:d5ba851d971ff8d796afd9a100acf55eaac0c197c6ab779787797ce66f419f0e",
+    "zh:e8c090d0c4f730c4a610dc4f0c22b177a0376d6f78679fc3f1d557b469e656f4",
+    "zh:ed7623acde26834672969dcb5befdb62900d9f216d32e7478a095d2b040a0ea7",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/external" {
-  version     = "2.3.2"
+  version     = "2.3.3"
   constraints = ">= 1.0.0"
   hashes = [
-    "h1:cy50n4q+Ir4GYppAfuYhQbBJVxMZbJUlIvM6FVK2axs=",
-    "zh:020bf652739ecd841d696e6c1b85ce7dd803e9177136df8fb03aa08b87365389",
-    "zh:0c7ea5a1cbf2e01a8627b8a84df69c93683f39fe947b288e958e72b9d12a827f",
-    "zh:25a68604c7d6aa736d6e99225051279eaac3a7cf4cab33b00ff7eae7096166f6",
-    "zh:34f46d82ca34604f6522de3b36eda19b7ad3be1e38947afc6ac31656eab58c8a",
-    "zh:6959f8f2f3de93e61e0abb90dbec41e28a66daec1607c46f43976bd6da50bcfd",
+    "h1:H+3QlVPs/7CDa3I4KU/a23wYeGeJxeBlgvR7bfK1t1w=",
+    "h1:Qi72kOSrEYgEt5itloFhDfmiFZ7wnRy3+F74XsRuUOw=",
+    "h1:gShzO1rJtADK9tDZMvMgjciVAzsBh39LNjtThCwX1Hg=",
+    "zh:03d81462f9578ec91ce8e26f887e34151eda0e100f57e9772dbea86363588239",
+    "zh:37ec2a20f6a3ec3a0fd95d3f3de26da6cb9534b30488bc45723e118a0911c0d8",
+    "zh:4eb5b119179539f2749ce9de0e1b9629d025990f062f4f4dddc161562bb89d37",
+    "zh:5a31bb58414f41bee5e09b939012df5b88654120b0238a89dfd6691ba197619a",
+    "zh:6221a05e52a6a2d4f520ffe7cbc741f4f6080e0855061b0ed54e8be4a84eb9b7",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:a81e5d65a343da9caa6f1d17ae0aced9faecb36b4f8554bd445dbd4f8be21ab6",
-    "zh:b1d3f1557214d652c9120862ce27e9a7b61cb5aec5537a28240a5a37bf0b1413",
-    "zh:b71588d006471ae2d4a7eca2c51d69fd7c5dec9b088315599b794e2ad0cc5e90",
-    "zh:cfdaae4028b644dff3530c77b49d31f7e6f4c4e2a9e5c8ac6a88e383c80c9e9c",
-    "zh:dbde15154c2eb38a5f54d0e7646bc67510004179696f3cc2bc1d877cecacf83b",
-    "zh:fb681b363f83fb5f64dfa6afbf32d100d0facd2a766cf3493b8ddb0398e1b0f7",
+    "zh:8bb068496b4679bef625e4710d9f3432e301c3a56602271f04e60eadf7f8a94c",
+    "zh:94742aa5378bab626ce34f79bcef6a373e4f86ea7a8b762e9f71270a899e0d00",
+    "zh:a485831b5a525cd8f40e8982fa37da40ff70b1ae092c8b755fcde123f0b1238d",
+    "zh:a647ff16d071eabcabd87ea8183eb90a775a0294ddd735d742075d62fff09193",
+    "zh:b74710c5954aaa3faf262c18d36a8c2407862d9f842c63e7fa92fa4de3d29df6",
+    "zh:fa73d83edc92af2e551857594c2232ba6a9e3603ad34b0a5940865202c08d8d7",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.4.0"
-  constraints = "2.4.0"
+  constraints = ">= 1.0.0, 2.4.0"
   hashes = [
     "h1:Bs7LAkV/iQTLv72j+cTMrvx2U3KyXrcVHaGbdns1NcE=",
     "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
@@ -73,6 +75,8 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 2.0.0"
   hashes = [
     "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
+    "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
     "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
     "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",

--- a/terraform/20-app/alb.feature-flags.tf
+++ b/terraform/20-app/alb.feature-flags.tf
@@ -1,0 +1,79 @@
+module "feature_flags_alb" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "8.7.0"
+
+  name = "${local.prefix}-feature-flags"
+
+  load_balancer_type = "application"
+
+  vpc_id                     = module.vpc.vpc_id
+  subnets                    = module.vpc.public_subnets
+  security_groups            = [module.feature_flags_alb_security_group.security_group_id]
+  drop_invalid_header_fields = true
+
+  access_logs = {
+    bucket  = data.aws_s3_bucket.elb_logs_eu_west_2.id
+    enabled = true
+    prefix  = "feature-flags-alb"
+  }
+
+  target_groups = [
+    {
+      name             = "${local.prefix}-feature-flags"
+      backend_protocol = "HTTP"
+      backend_port     = 4242
+      target_type      = "ip"
+      health_check     = {
+        enabled             = true
+        interval            = 30
+        path                = "/health/"
+        port                = "traffic-port"
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        timeout             = 5
+        protocol            = "HTTP"
+        matcher             = "200"
+      }
+    }
+  ]
+
+  https_listeners = [
+    {
+      port               = 443
+      protocol           = "HTTPS"
+      certificate_arn    = local.certificate_arn
+      target_group_index = 0
+      ssl_policy         = local.alb_security_policy
+    }
+  ]
+}
+
+module "feature_flags_alb_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name   = "${local.prefix}-feature-flags-alb"
+  vpc_id = module.vpc.vpc_id
+
+  ingress_with_cidr_blocks = [
+    {
+      description = "https from internet"
+      rule        = "https-443-tcp"
+      cidr_blocks = join(",",
+        local.ip_allow_list.engineers,
+        local.ip_allow_list.project_team,
+        local.ip_allow_list.other_stakeholders
+      )
+    }
+  ]
+
+  egress_with_source_security_group_id = [
+    {
+      description              = "lb to tasks"
+      from_port                = 4242
+      to_port                  = 4242
+      protocol                 = "tcp"
+      source_security_group_id = module.ecs_service_feature_flags.security_group_id
+    }
+  ]
+}

--- a/terraform/20-app/api-keys.tf
+++ b/terraform/20-app/api-keys.tf
@@ -23,6 +23,24 @@ resource "random_password" "backend_cryptographic_signing_key" {
   special     = true
 }
 
+resource "random_password" "feature_flags_client_api_key" {
+  length      = 56
+  min_numeric = 1
+  min_lower   = 1
+  special     = false
+  upper       = false
+}
+
+resource "random_password" "feature_flags_admin_user_password" {
+  length      = 20
+  min_numeric = 1
+  min_lower   = 1
+  min_upper   = 1
+  min_special = 1
+  special     = true
+}
+
 locals {
-  private_api_key = "${random_password.private_api_key_prefix.result}.${random_password.private_api_key_suffix.result}"
+  feature_flags_client_api_key = "*:production.${random_password.feature_flags_client_api_key.result}"
+  private_api_key              = "${random_password.private_api_key_prefix.result}.${random_password.private_api_key_suffix.result}"
 }

--- a/terraform/20-app/aurora-db.feature-flags.tf
+++ b/terraform/20-app/aurora-db.feature-flags.tf
@@ -1,0 +1,44 @@
+module "aurora_db_feature_flags" {
+  source = "terraform-aws-modules/rds-aurora/aws"
+
+  name              = "${local.prefix}-aurora-db-feature-flags"
+  engine            = "aurora-postgresql"
+  engine_mode       = "provisioned"
+  engine_version    = "15.5"
+  storage_encrypted = true
+
+  publicly_accessible = true
+
+  manage_master_user_password = false
+  database_name               = "unleash"
+  master_username             = jsondecode(aws_secretsmanager_secret_version.aurora_db_feature_flags_credentials.secret_string)["username"]
+  master_password             = jsondecode(aws_secretsmanager_secret_version.aurora_db_feature_flags_credentials.secret_string)["password"]
+
+  monitoring_interval = 60
+  apply_immediately   = true
+  skip_final_snapshot = true
+
+  instance_class                     = "db.serverless"
+  serverlessv2_scaling_configuration = {
+    min_capacity = 1
+    max_capacity = 10
+  }
+  instances = {
+    reader = {}
+    writer = {}
+  }
+
+  vpc_id               = module.vpc.vpc_id
+  db_subnet_group_name = module.vpc.database_subnet_group_name
+
+  security_group_rules = {
+    feature_flag_tasks_to_db = {
+      type                     = "ingress"
+      description              = "feature flags tasks to feature flags db"
+      protocol                 = "tcp"
+      from_port                = 4242
+      to_port                  = 5432
+      source_security_group_id = module.ecs_service_feature_flags.security_group_id
+    }
+  }
+}

--- a/terraform/20-app/ecs.service.feature-flags.tf
+++ b/terraform/20-app/ecs.service.feature-flags.tf
@@ -1,0 +1,120 @@
+module "ecs_service_feature_flags" {
+  source  = "terraform-aws-modules/ecs/aws//modules/service"
+  version = "5.2.0"
+
+  name                   = "${local.prefix}-feature-flags"
+  cluster_arn            = module.ecs.cluster_arn
+  enable_execute_command = true
+
+  create_iam_role = true
+
+  cpu        = 256
+  memory     = 512
+  subnet_ids = module.vpc.private_subnets
+
+  enable_autoscaling       = false
+  desired_count            = 1
+  autoscaling_min_capacity = 1
+  autoscaling_max_capacity = 1
+
+  container_definitions = {
+    api = {
+      cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
+      cpu                                    = 256
+      memory                                 = 512
+      essential                              = true
+      readonly_root_filesystem               = false
+      image                                  = "unleashorg/unleash-server:5.10.1"
+      port_mappings                          = [
+        {
+          containerPort = 4242
+          hostPort      = 4242
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        {
+          name  = "UNLEASH_URL"
+          value = local.urls.feature_flags
+        },
+        {
+          name  = "UNLEASH_PROXY_CLIENT_KEYS"
+          value = "Authorization"
+        },
+        {
+          name  = "DATABASE_HOST"
+          value = module.aurora_db_feature_flags.cluster_endpoint
+        },
+        {
+          name  = "DATABASE_NAME"
+          value = module.aurora_db_feature_flags.cluster_database_name
+        },
+      ],
+      secrets = [
+        {
+          name      = "INIT_CLIENT_API_TOKENS"
+          valueFrom = "${aws_secretsmanager_secret.feature_flags_api_keys.arn}:client_api_key::"
+        },
+        {
+          name      = "UNLEASH_DEFAULT_ADMIN_USERNAME"
+          valueFrom = "${aws_secretsmanager_secret.feature_flags_admin_user_credentials.arn}:username::"
+        },
+        {
+          name      = "UNLEASH_DEFAULT_ADMIN_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret.feature_flags_admin_user_credentials.arn}:password::"
+        },
+        {
+          name      = "DATABASE_USERNAME"
+          valueFrom = "${aws_secretsmanager_secret.aurora_db_feature_flags_credentials.arn}:username::"
+        },
+        {
+          name      = "DATABASE_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret.aurora_db_feature_flags_credentials.arn}:password::"
+        },
+      ]
+    }
+  }
+
+  load_balancer = {
+    service = {
+      target_group_arn = element(module.feature_flags_alb.target_group_arns, 0)
+      container_name   = "api"
+      container_port   = 4242
+    }
+  }
+}
+
+
+module "feature_flags_tasks_security_group_rules" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  create_sg         = false
+  security_group_id = module.ecs_service_feature_flags.security_group_id
+
+  ingress_with_source_security_group_id = [
+    {
+      description              = "lb to tasks"
+      from_port                = 4242
+      to_port                  = 4242
+      protocol                 = "tcp"
+      source_security_group_id = module.feature_flags_alb_security_group.security_group_id
+    }
+  ]
+
+  egress_with_cidr_blocks = [
+    {
+      description = "https to internet"
+      rule        = "https-443-tcp"
+      cidr_blocks = "0.0.0.0/0"
+    }
+  ]
+
+  egress_with_source_security_group_id = [
+    {
+      description              = "lb to feature flags db"
+      rule                     = "postgresql-tcp"
+      source_security_group_id = module.aurora_db_feature_flags.security_group_id
+    }
+  ]
+}

--- a/terraform/20-app/ecs.service.feature-flags.tf
+++ b/terraform/20-app/ecs.service.feature-flags.tf
@@ -8,8 +8,12 @@ module "ecs_service_feature_flags" {
 
   create_iam_role = true
 
-  cpu        = 256
-  memory     = 512
+  cpu              = 256
+  memory           = 512
+  runtime_platform = {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = false

--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -23,7 +23,7 @@ module "ecs_service_front_end" {
       essential                              = true
       readonly_root_filesystem               = false
       image                                  = "${module.ecr_front_end.repository_url}:latest"
-      port_mappings = [
+      port_mappings                          = [
         {
           containerPort = 3000
           hostPort      = 3000

--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -52,6 +52,10 @@ module "ecs_service_front_end" {
         {
           name      = "GOOGLE_TAG_MANAGER_ID",
           valueFrom = "${aws_secretsmanager_secret.google_analytics_credentials.arn}:google_tag_manager_id::"
+        },
+        {
+          name      = "FEATURE_FLAGS_API_KEY",
+          valueFrom = "${aws_secretsmanager_secret.feature_flags_api_keys.arn}:client_api_key::"
         }
       ]
     }

--- a/terraform/20-app/locals.tf
+++ b/terraform/20-app/locals.tf
@@ -39,7 +39,8 @@ locals {
     private_api      = "private-api.${local.account_layer.dns.wke_dns_names[local.environment]}"
     public_api       = "api.${local.account_layer.dns.wke_dns_names[local.environment]}"
     public_api_lb    = "api-lb.${local.account_layer.dns.wke_dns_names[local.environment]}"
-    } : {
+    feature_flags    = "feature-flags.${local.account_layer.dns.wke_dns_names[local.environment]}"
+  } : {
     archive          = "${local.environment}-archive.${local.account_layer.dns.account.dns_name}"
     cms_admin        = "${local.environment}-cms.${local.account_layer.dns.account.dns_name}"
     feedback_api     = "${local.environment}-feedback-api.${local.account_layer.dns.account.dns_name}"
@@ -49,5 +50,6 @@ locals {
     private_api      = "${local.environment}-private-api.${local.account_layer.dns.account.dns_name}"
     public_api       = "${local.environment}-api.${local.account_layer.dns.account.dns_name}"
     public_api_lb    = "${local.environment}-api-lb.${local.account_layer.dns.account.dns_name}"
+    feature_flags    = "${local.environment}-feature-flags.${local.account_layer.dns.account.dns_name}"
   }
 }

--- a/terraform/20-app/outputs.tf
+++ b/terraform/20-app/outputs.tf
@@ -31,6 +31,7 @@ locals {
     private_api      = "https://${local.dns_names.private_api}"
     public_api       = "https://${local.dns_names.public_api}"
     public_api_lb    = "https://${local.dns_names.public_api_lb}"
+    feature_flags    = "https://${local.dns_names.feature_flags}"
   }
 }
 

--- a/terraform/20-app/passwords.tf
+++ b/terraform/20-app/passwords.tf
@@ -7,6 +7,14 @@ resource "random_password" "rds_db_password" {
   special     = false
 }
 
+resource "random_password" "feature_flags_db_password" {
+  length      = 20
+  min_lower   = 1
+  min_numeric = 1
+  min_upper   = 1
+  special     = false
+}
+
 resource "random_password" "cms_admin_user_password" {
   length      = 10
   min_numeric = 1

--- a/terraform/20-app/route-53.tf
+++ b/terraform/20-app/route-53.tf
@@ -6,67 +6,75 @@ module "route_53_records" {
 
   records = [
     {
-      name = local.environment
-      type = "A"
+      name  = local.environment
+      type  = "A"
       alias = {
         name    = module.cloudfront_front_end.cloudfront_distribution_domain_name
         zone_id = module.cloudfront_front_end.cloudfront_distribution_hosted_zone_id
       }
     },
     {
-      name = "${local.environment}-lb"
-      type = "A"
+      name  = "${local.environment}-lb"
+      type  = "A"
       alias = {
         name    = module.front_end_alb.lb_dns_name
         zone_id = module.front_end_alb.lb_zone_id
       }
     },
     {
-      name = "${local.environment}-api"
-      type = "A"
+      name  = "${local.environment}-api"
+      type  = "A"
       alias = {
         name    = module.cloudfront_public_api.cloudfront_distribution_domain_name
         zone_id = module.cloudfront_public_api.cloudfront_distribution_hosted_zone_id
       }
     },
     {
-      name = "${local.environment}-api-lb"
-      type = "A"
+      name  = "${local.environment}-api-lb"
+      type  = "A"
       alias = {
         name    = module.public_api_alb.lb_dns_name
         zone_id = module.public_api_alb.lb_zone_id
       }
     },
     {
-      name = "${local.environment}-private-api",
-      type = "A"
+      name  = "${local.environment}-private-api",
+      type  = "A"
       alias = {
         name    = module.private_api_alb.lb_dns_name
         zone_id = module.private_api_alb.lb_zone_id
       }
     },
     {
-      name = "${local.environment}-feedback-api",
-      type = "A"
+      name  = "${local.environment}-feedback-api",
+      type  = "A"
       alias = {
         name    = module.feedback_api_alb.lb_dns_name
         zone_id = module.feedback_api_alb.lb_zone_id
       }
     },
     {
-      name = "${local.environment}-cms"
-      type = "A"
+      name  = "${local.environment}-cms"
+      type  = "A"
       alias = {
         name    = module.cms_admin_alb.lb_dns_name
         zone_id = module.cms_admin_alb.lb_zone_id
       }
     },
     {
-      name = "${local.environment}-archive"
-      type = "A"
+      name  = "${local.environment}-archive"
+      type  = "A"
       alias = {
         name    = module.cloudfront_archive_web_content.cloudfront_distribution_domain_name
         zone_id = module.cloudfront_archive_web_content.cloudfront_distribution_hosted_zone_id
+      }
+    },
+    {
+      name  = "${local.environment}-feature-flags"
+      type  = "A"
+      alias = {
+        name    = module.feature_flags_alb.lb_dns_name
+        zone_id = module.feature_flags_alb.lb_zone_id
       }
     }
   ]

--- a/terraform/20-app/route-53.wke-account.tf
+++ b/terraform/20-app/route-53.wke-account.tf
@@ -7,67 +7,75 @@ module "route_53_records_wke_account" {
 
   records = [
     {
-      name = ""
-      type = "A"
+      name  = ""
+      type  = "A"
       alias = {
         name    = module.cloudfront_front_end.cloudfront_distribution_domain_name
         zone_id = module.cloudfront_front_end.cloudfront_distribution_hosted_zone_id
       }
     },
     {
-      name = "lb"
-      type = "A"
+      name  = "lb"
+      type  = "A"
       alias = {
         name    = module.front_end_alb.lb_dns_name
         zone_id = module.front_end_alb.lb_zone_id
       }
     },
     {
-      name = "api"
-      type = "A"
+      name  = "api"
+      type  = "A"
       alias = {
         name    = module.cloudfront_front_end.cloudfront_distribution_domain_name
         zone_id = module.cloudfront_front_end.cloudfront_distribution_hosted_zone_id
       }
     },
     {
-      name = "api-lb"
-      type = "A"
+      name  = "api-lb"
+      type  = "A"
       alias = {
         name    = module.public_api_alb.lb_dns_name
         zone_id = module.public_api_alb.lb_zone_id
       }
     },
     {
-      name = "private-api"
-      type = "A"
+      name  = "private-api"
+      type  = "A"
       alias = {
         name    = module.private_api_alb.lb_dns_name
         zone_id = module.private_api_alb.lb_zone_id
       }
     },
     {
-      name = "feedback-api"
-      type = "A"
+      name  = "feedback-api"
+      type  = "A"
       alias = {
         name    = module.feedback_api_alb.lb_dns_name
         zone_id = module.feedback_api_alb.lb_zone_id
       }
     },
     {
-      name = "cms"
-      type = "A"
+      name  = "cms"
+      type  = "A"
       alias = {
         name    = module.cms_admin_alb.lb_dns_name
         zone_id = module.cms_admin_alb.lb_zone_id
       }
     },
     {
-      name = "archive"
-      type = "A"
+      name  = "archive"
+      type  = "A"
       alias = {
         name    = module.cloudfront_archive_web_content.cloudfront_distribution_domain_name
         zone_id = module.cloudfront_archive_web_content.cloudfront_distribution_hosted_zone_id
+      }
+    },
+    {
+      name  = "feature-flags"
+      type  = "A"
+      alias = {
+        name    = module.feature_flags_alb.lb_dns_name
+        zone_id = module.feature_flags_alb.lb_zone_id
       }
     }
   ]

--- a/terraform/20-app/route-53.wke-others.tf
+++ b/terraform/20-app/route-53.wke-others.tf
@@ -7,67 +7,75 @@ module "route_53_records_wke_others" {
 
   records = [
     {
-      name = ""
-      type = "A"
+      name  = ""
+      type  = "A"
       alias = {
         name    = module.cloudfront_front_end.cloudfront_distribution_domain_name
         zone_id = module.cloudfront_front_end.cloudfront_distribution_hosted_zone_id
       }
     },
     {
-      name = "lb"
-      type = "A"
+      name  = "lb"
+      type  = "A"
       alias = {
         name    = module.front_end_alb.lb_dns_name
         zone_id = module.front_end_alb.lb_zone_id
       }
     },
     {
-      name = "api"
-      type = "A"
+      name  = "api"
+      type  = "A"
       alias = {
         name    = module.cloudfront_front_end.cloudfront_distribution_domain_name
         zone_id = module.cloudfront_front_end.cloudfront_distribution_hosted_zone_id
       }
     },
     {
-      name = "api-lb"
-      type = "A"
+      name  = "api-lb"
+      type  = "A"
       alias = {
         name    = module.public_api_alb.lb_dns_name
         zone_id = module.public_api_alb.lb_zone_id
       }
     },
     {
-      name = "private-api"
-      type = "A"
+      name  = "private-api"
+      type  = "A"
       alias = {
         name    = module.private_api_alb.lb_dns_name
         zone_id = module.private_api_alb.lb_zone_id
       }
     },
     {
-      name = "feedback-api"
-      type = "A"
+      name  = "feedback-api"
+      type  = "A"
       alias = {
         name    = module.feedback_api_alb.lb_dns_name
         zone_id = module.feedback_api_alb.lb_zone_id
       }
     },
     {
-      name = "cms"
-      type = "A"
+      name  = "cms"
+      type  = "A"
       alias = {
         name    = module.cms_admin_alb.lb_dns_name
         zone_id = module.cms_admin_alb.lb_zone_id
       }
     },
     {
-      name = "archive"
-      type = "A"
+      name  = "archive"
+      type  = "A"
       alias = {
         name    = module.cloudfront_archive_web_content.cloudfront_distribution_domain_name
         zone_id = module.cloudfront_archive_web_content.cloudfront_distribution_hosted_zone_id
+      }
+    },
+    {
+      name  = "feature-flags"
+      type  = "A"
+      alias = {
+        name    = module.feature_flags_alb.lb_dns_name
+        zone_id = module.feature_flags_alb.lb_zone_id
       }
     }
   ]

--- a/terraform/20-app/secret-manager.tf
+++ b/terraform/20-app/secret-manager.tf
@@ -15,6 +15,21 @@ resource "aws_secretsmanager_secret_version" "rds_db_creds" {
 }
 
 ################################################################################
+# Feature flags database credentials
+################################################################################
+
+resource "aws_secretsmanager_secret" "aurora_db_feature_flags_credentials" {
+  name = "${local.prefix}-aurora-db-feature-flags-credentials"
+}
+
+resource "aws_secretsmanager_secret_version" "aurora_db_feature_flags_credentials" {
+  secret_id     = aws_secretsmanager_secret.aurora_db_feature_flags_credentials.id
+  secret_string = jsonencode({
+    username = "unleash_user"
+    password = random_password.feature_flags_db_password.result
+  })
+}
+################################################################################
 # CMS admin application credentials
 ################################################################################
 

--- a/terraform/20-app/secret-manager.tf
+++ b/terraform/20-app/secret-manager.tf
@@ -29,6 +29,39 @@ resource "aws_secretsmanager_secret_version" "aurora_db_feature_flags_credential
     password = random_password.feature_flags_db_password.result
   })
 }
+
+################################################################################
+# Feature flags
+################################################################################
+
+resource "aws_secretsmanager_secret" "feature_flags_api_keys" {
+  name        = "${local.prefix}-feature-flags-api-keys"
+  description = "These are the API key required when interacting with the feature flags service."
+
+}
+
+resource "aws_secretsmanager_secret_version" "feature_flags_api_keys" {
+  secret_id     = aws_secretsmanager_secret.feature_flags_api_keys.id
+  secret_string = jsonencode({
+    client_api_key = local.feature_flags_client_api_key
+  })
+}
+
+
+resource "aws_secretsmanager_secret" "feature_flags_admin_user_credentials" {
+  name        = "${local.prefix}-feature-flags-admin-user-credentials"
+  description = "These are the default admin credentials required to login to the feature flags application."
+
+}
+
+resource "aws_secretsmanager_secret_version" "feature_flags_admin_user_credentials" {
+  secret_id     = aws_secretsmanager_secret.feature_flags_admin_user_credentials.id
+  secret_string = jsonencode({
+    username = "admin"
+    password = random_password.feature_flags_admin_user_password.result
+  })
+}
+
 ################################################################################
 # CMS admin application credentials
 ################################################################################

--- a/terraform/20-app/secret-manager.tf
+++ b/terraform/20-app/secret-manager.tf
@@ -1,5 +1,5 @@
 ################################################################################
-# Database credentials
+# Main database credentials
 ################################################################################
 
 resource "aws_secretsmanager_secret" "rds_db_creds" {

--- a/terraform/20-app/versions.tf
+++ b/terraform/20-app/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.32.1"
+      version = "5.41.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/20-app/versions.tf
+++ b/terraform/20-app/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.41.0"
+      version = "5.42.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/20-app/waf.feature-flags.tf
+++ b/terraform/20-app/waf.feature-flags.tf
@@ -1,0 +1,103 @@
+resource "aws_wafv2_web_acl" "feature_flags" {
+  name        = "${local.prefix}-feature-flags"
+  description = "Web ACL for the feature flags application"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          action_to_use {
+            allow {}
+          }
+          name = "SizeRestrictions_BODY"
+        }
+      }
+    }
+
+    visibility_config {
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+    }
+  }
+
+  dynamic "rule" {
+    for_each = local.waf_feature_flags.rules
+
+    content {
+      name     = rule.value.name
+      priority = rule.value.priority
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          name        = rule.value.name
+          vendor_name = "AWS"
+        }
+      }
+
+      visibility_config {
+        metric_name                = rule.value.name
+        cloudwatch_metrics_enabled = true
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  visibility_config {
+    metric_name                = "${local.prefix}-feature-flags"
+    cloudwatch_metrics_enabled = true
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "feature-flags" {
+  resource_arn = module.feature_flags_alb.lb_arn
+  web_acl_arn  = aws_wafv2_web_acl.feature_flags.arn
+}
+
+locals {
+  waf_feature_flags = {
+    rules = [
+      {
+        priority = 2
+        name     = "AWSManagedRulesKnownBadInputsRuleSet"
+      },
+      {
+        priority = 3
+        name     = "AWSManagedRulesAmazonIpReputationList"
+      },
+      {
+        priority = 4
+        name     = "AWSManagedRulesLinuxRuleSet"
+      },
+      {
+        priority = 5
+        name     = "AWSManagedRulesUnixRuleSet"
+      }
+    ]
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "feature_flags" {
+  log_destination_configs = [data.aws_s3_bucket.halo_waf_logs_eu_west_2.arn]
+  resource_arn            = aws_wafv2_web_acl.feature_flags.arn
+}


### PR DESCRIPTION
This includes the following:

- New dedicated aurora db 
- ECS service + load balancer
- Web app firewall in front of the application
- Restricted with the IP allow list
- Admin password & API key generated and saved in 
- DNS records for the unleash admin application

Proxy is not included in this PR and neither is the pull through ECR cache since we’re pulling the image directly from the official unleash docker hub repo for now.