### PR TITLE
Add scheduled autoscaling policies to all ECS tasks in dev environments to spin down at 8pm and back up at 7am

### DIFF
--- a/terraform/20-app/ecs.service.cms-admin.tf
+++ b/terraform/20-app/ecs.service.cms-admin.tf
@@ -11,11 +11,11 @@ module "ecs_service_cms_admin" {
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
-  desired_count            = local.use_auto_scaling ? 3 : 1
-  autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
-  autoscaling_max_capacity = local.use_auto_scaling ? 5 : 1
+  desired_count            = local.use_prod_sizing ? 3 : 1
+  autoscaling_min_capacity = local.use_prod_sizing ? 3 : 1
+  autoscaling_max_capacity = local.use_prod_sizing ? 5 : 1
 
-  autoscaling_scheduled_actions = local.is_dev ? local.scheduled_autoscaling_policies_for_dev_environments : {}
+  autoscaling_scheduled_actions = local.use_prod_sizing ? {} : local.scheduled_scaling_policies_for_non_essential_envs
 
   container_definitions = {
     api = {

--- a/terraform/20-app/ecs.service.cms-admin.tf
+++ b/terraform/20-app/ecs.service.cms-admin.tf
@@ -10,10 +10,12 @@ module "ecs_service_cms_admin" {
   memory     = local.use_prod_sizing ? 4096 : 1024
   subnet_ids = module.vpc.private_subnets
 
-  enable_autoscaling       = local.use_auto_scaling
+  enable_autoscaling       = true
   desired_count            = local.use_auto_scaling ? 3 : 1
   autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
   autoscaling_max_capacity = local.use_auto_scaling ? 5 : 1
+
+  autoscaling_scheduled_actions = local.is_dev ? local.scheduled_autoscaling_policies_for_dev_environments : {}
 
   container_definitions = {
     api = {
@@ -23,7 +25,7 @@ module "ecs_service_cms_admin" {
       essential                              = true
       readonly_root_filesystem               = false
       image                                  = "${module.ecr_api.repository_url}:latest"
-      port_mappings = [
+      port_mappings                          = [
         {
           containerPort = 80
           hostPort      = 80

--- a/terraform/20-app/ecs.service.feedback-api.tf
+++ b/terraform/20-app/ecs.service.feedback-api.tf
@@ -11,11 +11,11 @@ module "ecs_service_feedback_api" {
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
-  desired_count            = local.use_auto_scaling ? 3 : 1
-  autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
-  autoscaling_max_capacity = local.use_auto_scaling ? 20 : 1
+  desired_count            = local.use_prod_sizing ? 3 : 1
+  autoscaling_min_capacity = local.use_prod_sizing ? 3 : 1
+  autoscaling_max_capacity = local.use_prod_sizing ? 20 : 1
 
-  autoscaling_scheduled_actions = local.is_dev ? local.scheduled_autoscaling_policies_for_dev_environments : {}
+  autoscaling_scheduled_actions = local.use_prod_sizing ? {} : local.scheduled_scaling_policies_for_non_essential_envs
 
   container_definitions = {
     api = {

--- a/terraform/20-app/ecs.service.feedback-api.tf
+++ b/terraform/20-app/ecs.service.feedback-api.tf
@@ -10,10 +10,12 @@ module "ecs_service_feedback_api" {
   memory     = local.use_prod_sizing ? 4096 : 1024
   subnet_ids = module.vpc.private_subnets
 
-  enable_autoscaling       = local.use_auto_scaling
+  enable_autoscaling       = local.true
   desired_count            = local.use_auto_scaling ? 3 : 1
   autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
   autoscaling_max_capacity = local.use_auto_scaling ? 20 : 1
+
+  autoscaling_scheduled_actions = local.is_dev ? local.scheduled_autoscaling_policies_for_dev_environments : {}
 
   container_definitions = {
     api = {

--- a/terraform/20-app/ecs.service.feedback-api.tf
+++ b/terraform/20-app/ecs.service.feedback-api.tf
@@ -10,7 +10,7 @@ module "ecs_service_feedback_api" {
   memory     = local.use_prod_sizing ? 4096 : 1024
   subnet_ids = module.vpc.private_subnets
 
-  enable_autoscaling       = local.true
+  enable_autoscaling       = true
   desired_count            = local.use_auto_scaling ? 3 : 1
   autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
   autoscaling_max_capacity = local.use_auto_scaling ? 20 : 1

--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -10,10 +10,13 @@ module "ecs_service_front_end" {
   memory     = local.use_prod_sizing ? 4096 : 1024
   subnet_ids = module.vpc.private_subnets
 
-  enable_autoscaling       = local.use_auto_scaling
+  enable_autoscaling       = true
   desired_count            = local.use_auto_scaling ? 3 : 1
   autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
   autoscaling_max_capacity = local.use_auto_scaling ? 20 : 1
+
+  autoscaling_scheduled_actions = local.is_dev ? local.scheduled_autoscaling_policies_for_dev_environments : {}
+
 
   container_definitions = {
     front-end = {

--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -11,12 +11,11 @@ module "ecs_service_front_end" {
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
-  desired_count            = local.use_auto_scaling ? 3 : 1
-  autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
-  autoscaling_max_capacity = local.use_auto_scaling ? 20 : 1
+  desired_count            = local.use_prod_sizing ? 3 : 1
+  autoscaling_min_capacity = local.use_prod_sizing ? 3 : 1
+  autoscaling_max_capacity = local.use_prod_sizing ? 20 : 1
 
-  autoscaling_scheduled_actions = local.is_dev ? local.scheduled_autoscaling_policies_for_dev_environments : {}
-
+  autoscaling_scheduled_actions = local.use_prod_sizing ? {} : local.scheduled_scaling_policies_for_non_essential_envs
 
   container_definitions = {
     front-end = {
@@ -26,7 +25,7 @@ module "ecs_service_front_end" {
       essential                              = true
       readonly_root_filesystem               = false
       image                                  = "${module.ecr_front_end.repository_url}:latest"
-      port_mappings = [
+      port_mappings                          = [
         {
           containerPort = 3000
           hostPort      = 3000

--- a/terraform/20-app/ecs.service.private-api.tf
+++ b/terraform/20-app/ecs.service.private-api.tf
@@ -10,10 +10,12 @@ module "ecs_service_private_api" {
   memory     = local.use_prod_sizing ? 4096 : 1024
   subnet_ids = module.vpc.private_subnets
 
-  enable_autoscaling       = local.use_auto_scaling
+  enable_autoscaling       = true
   desired_count            = local.use_auto_scaling ? 3 : 1
   autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
   autoscaling_max_capacity = local.use_auto_scaling ? 20 : 1
+
+  autoscaling_scheduled_actions = local.is_dev ? local.scheduled_autoscaling_policies_for_dev_environments : {}
 
   security_group_ids = [module.app_elasticache_security_group.security_group_id]
 

--- a/terraform/20-app/ecs.service.private-api.tf
+++ b/terraform/20-app/ecs.service.private-api.tf
@@ -11,11 +11,11 @@ module "ecs_service_private_api" {
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
-  desired_count            = local.use_auto_scaling ? 3 : 1
-  autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
-  autoscaling_max_capacity = local.use_auto_scaling ? 20 : 1
+  desired_count            = local.use_prod_sizing ? 3 : 1
+  autoscaling_min_capacity = local.use_prod_sizing ? 3 : 1
+  autoscaling_max_capacity = local.use_prod_sizing ? 20 : 1
 
-  autoscaling_scheduled_actions = local.is_dev ? local.scheduled_autoscaling_policies_for_dev_environments : {}
+  autoscaling_scheduled_actions = local.use_prod_sizing ? {} : local.scheduled_scaling_policies_for_non_essential_envs
 
   security_group_ids = [module.app_elasticache_security_group.security_group_id]
 

--- a/terraform/20-app/ecs.service.public-api.tf
+++ b/terraform/20-app/ecs.service.public-api.tf
@@ -11,11 +11,11 @@ module "ecs_service_public_api" {
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
-  desired_count            = local.use_auto_scaling ? 3 : 1
-  autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
-  autoscaling_max_capacity = local.use_auto_scaling ? 20 : 1
+  desired_count            = local.use_prod_sizing ? 3 : 1
+  autoscaling_min_capacity = local.use_prod_sizing ? 3 : 1
+  autoscaling_max_capacity = local.use_prod_sizing ? 20 : 1
 
-  autoscaling_scheduled_actions = local.is_dev ? local.scheduled_autoscaling_policies_for_dev_environments : {}
+  autoscaling_scheduled_actions = local.use_prod_sizing ? {} : local.scheduled_scaling_policies_for_non_essential_envs
 
   container_definitions = {
     api = {

--- a/terraform/20-app/ecs.service.public-api.tf
+++ b/terraform/20-app/ecs.service.public-api.tf
@@ -10,10 +10,12 @@ module "ecs_service_public_api" {
   memory     = local.use_prod_sizing ? 4096 : 1024
   subnet_ids = module.vpc.private_subnets
 
-  enable_autoscaling       = local.use_auto_scaling
+  enable_autoscaling       = true
   desired_count            = local.use_auto_scaling ? 3 : 1
   autoscaling_min_capacity = local.use_auto_scaling ? 3 : 1
   autoscaling_max_capacity = local.use_auto_scaling ? 20 : 1
+
+  autoscaling_scheduled_actions = local.is_dev ? local.scheduled_autoscaling_policies_for_dev_environments : {}
 
   container_definitions = {
     api = {

--- a/terraform/20-app/locals.tf
+++ b/terraform/20-app/locals.tf
@@ -24,13 +24,12 @@ locals {
   enable_public_db            = local.is_dev
   is_dev                      = var.environment_type == "dev"
 
-  use_auto_scaling  = local.use_prod_sizing
-  use_ip_allow_list = local.environment != "prod"
+  use_ip_allow_list             = local.environment != "prod"
 
-  scheduled_autoscaling_policies_for_dev_environments = {
+  scheduled_scaling_policies_for_non_essential_envs = {
     start_of_working_day_scale_out = {
-      min_capacity = 1
-      max_capacity = 1
+      min_capacity = local.use_prod_sizing ? 3 : 1
+      max_capacity = local.use_prod_sizing ? 3 : 1
       schedule     = "cron(0 07 ? * MON-FRI *)"   # Run every weekday at 7am
     }
     end_of_working_day_scale_in = {

--- a/terraform/20-app/locals.tf
+++ b/terraform/20-app/locals.tf
@@ -27,6 +27,19 @@ locals {
   use_auto_scaling  = local.use_prod_sizing
   use_ip_allow_list = local.environment != "prod"
 
+  scheduled_autoscaling_policies_for_dev_environments = {
+    start_of_working_day_scale_out = {
+      min_capacity = 1
+      max_capacity = 1
+      schedule     = "cron(0 07 ? * MON-FRI *)"   # Run every weekday at 7am
+    }
+    end_of_working_day_scale_in = {
+      min_capacity = 0
+      max_capacity = 0
+      schedule     = "cron(0 20 ? * MON-FRI *)"   # Run every weekday at 8pm
+    }
+  }
+
   ship_cloud_watch_logs_to_splunk = true
 
   dns_names = contains(concat(local.wke.account, local.wke.other), local.environment) ? {
@@ -39,7 +52,7 @@ locals {
     private_api      = "private-api.${local.account_layer.dns.wke_dns_names[local.environment]}"
     public_api       = "api.${local.account_layer.dns.wke_dns_names[local.environment]}"
     public_api_lb    = "api-lb.${local.account_layer.dns.wke_dns_names[local.environment]}"
-    } : {
+  } : {
     archive          = "${local.environment}-archive.${local.account_layer.dns.account.dns_name}"
     cms_admin        = "${local.environment}-cms.${local.account_layer.dns.account.dns_name}"
     feedback_api     = "${local.environment}-feedback-api.${local.account_layer.dns.account.dns_name}"


### PR DESCRIPTION
- Adds scheduled autoscaling policies to all ECS tasks in dev environments 
- Scales in at 8pm every night
- Remains scaled in over weekends
- Scales out at 7am every morning