### PR TITLE
Pull application images from ECR in tools account

### DIFF
--- a/scripts/_docker.sh
+++ b/scripts/_docker.sh
@@ -104,7 +104,11 @@ function _docker_ecr_login() {
 
     echo "Logging into ECR in account $account"
 
-    account_id=$(_get_tools_account_id)
+    if [[ $account = "tools" ]]; then
+      account_id=$(_get_tools_account_id)
+    else
+      account_id=$(_get_target_aws_account_id $account)
+    fi
 
     aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin "${account_id}.dkr.ecr.eu-west-2.amazonaws.com"
 }

--- a/scripts/_docker.sh
+++ b/scripts/_docker.sh
@@ -58,11 +58,11 @@ function _docker_build() {
 }
 
 function _docker_pull() {
-    src_account_id=$(_get_target_aws_account_id "dev")
+    src_account_id=$(_get_tools_account_id)
     
-    src=("${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/wp-api:latest"
-         "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/wp-ingestion:latest"
-         "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/wp-frontend:latest")
+    src=("${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/data-dashboard/api:latest"
+         "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/data-dashboard/ingestion:latest"
+         "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/data-dashboard/front-end:latest")
 
     echo $src | xargs -P10 -n1 docker pull
 }
@@ -81,12 +81,12 @@ function _docker_push() {
         return 1
     fi
 
-    src_account_id=$(_get_target_aws_account_id "dev")
+    src_account_id=$(_get_tools_account_id)
     dest_account_id=$(_get_target_aws_account_id $account)
     
-    src=("${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/wp-api:latest"
-         "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/wp-ingestion:latest"
-         "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/wp-frontend:latest")
+    src=("${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/data-dashboard/api:latest"
+         "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/data-dashboard/ingestion:latest"
+         "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/data-dashboard/front-end:latest")
 
     dest=("${dest_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-api:latest"
           "${dest_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-ingestion:latest"
@@ -100,11 +100,11 @@ function _docker_push() {
 }
 
 function _docker_ecr_login() {
-    local account=${1:-dev}
+    local account=${1:-tools}
 
     echo "Logging into ECR in account $account"
 
-    account_id=$(_get_target_aws_account_id $account)
-    
+    account_id=$(_get_tools_account_id)
+
     aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin "${account_id}.dkr.ecr.eu-west-2.amazonaws.com"
 }

--- a/terraform/20-app/ecs.service.feedback-api.tf
+++ b/terraform/20-app/ecs.service.feedback-api.tf
@@ -6,8 +6,8 @@ module "ecs_service_feedback_api" {
   cluster_arn            = module.ecs.cluster_arn
   enable_execute_command = true
 
-  cpu        = local.use_prod_sizing ? 1024 : 256
-  memory     = local.use_prod_sizing ? 2048 : 512
+  cpu        = local.use_prod_sizing ? 1024 : 512
+  memory     = local.use_prod_sizing ? 2048 : 1024
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = local.use_auto_scaling
@@ -18,8 +18,8 @@ module "ecs_service_feedback_api" {
   container_definitions = {
     api = {
       cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
-      cpu                                    = local.use_prod_sizing ? 1024 : 256
-      memory                                 = local.use_prod_sizing ? 2048 : 512
+      cpu                                    = local.use_prod_sizing ? 1024 : 512
+      memory                                 = local.use_prod_sizing ? 2048 : 1024
       essential                              = true
       readonly_root_filesystem               = false
       image                                  = "${module.ecr_api.repository_url}:latest"


### PR DESCRIPTION
Reconfigures our CLI tooling so that it pulls the application images from the central ECR in the tools account instead of the deprecated one in the dev account