### PR TITLE
Exclude `Accept-Encoding` header in key for cloudfront cache policy

### DIFF
--- a/terraform/20-app/cloud-front.public-api.tf
+++ b/terraform/20-app/cloud-front.public-api.tf
@@ -93,9 +93,6 @@ resource "aws_cloudfront_cache_policy" "public_api" {
   default_ttl = local.use_prod_cloudfront_ttl ? 2592000 : 900
 
   parameters_in_cache_key_and_forwarded_to_origin {
-    enable_accept_encoding_brotli = true
-    enable_accept_encoding_gzip   = true
-
     cookies_config {
       cookie_behavior = "none"
     }


### PR DESCRIPTION
I'll follow up with another PR to add some logging later