### PR TITLE
Bug/cloudfront misses for public api apply correct ttl/cdd 1861

### DIFF
--- a/terraform/20-app/cloud-front.front-end.tf
+++ b/terraform/20-app/cloud-front.front-end.tf
@@ -56,6 +56,11 @@ module "cloudfront_front_end" {
     error_code            = 404
     error_caching_min_ttl = local.use_prod_cloudfront_ttl ? 2592000 : 900
   }]
+  custom_error_response = [
+    {
+      error_code            = 404
+    }
+  ]
 
   logging_config = {
     bucket          = data.aws_s3_bucket.cloud_front_logs_eu_west_2.bucket_domain_name

--- a/terraform/20-app/cloud-front.front-end.tf
+++ b/terraform/20-app/cloud-front.front-end.tf
@@ -1,3 +1,7 @@
+locals {
+  fifteen_minutes_in_seconds = 86400
+}
+
 module "cloudfront_front_end" {
   source  = "terraform-aws-modules/cloudfront/aws"
   version = "3.4.0"
@@ -52,13 +56,10 @@ module "cloudfront_front_end" {
     viewer_protocol_policy     = "redirect-to-https"
   }
 
-  custom_error_response = [{
-    error_code            = 404
-    error_caching_min_ttl = local.use_prod_cloudfront_ttl ? 2592000 : 900
-  }]
   custom_error_response = [
     {
       error_code            = 404
+      error_caching_min_ttl = local.use_prod_sizing ? local.thirty_days_in_seconds : local.fifteen_minutes_in_seconds
     }
   ]
 
@@ -87,9 +88,9 @@ resource "aws_cloudfront_origin_request_policy" "front_end" {
 resource "aws_cloudfront_cache_policy" "front_end" {
   name = "${local.prefix}-front-end"
 
-  min_ttl     = local.use_prod_cloudfront_ttl ? 2592000 : 900
-  max_ttl     = local.use_prod_cloudfront_ttl ? 2592000 : 900
-  default_ttl = local.use_prod_cloudfront_ttl ? 2592000 : 900
+  min_ttl     = local.use_prod_sizing ? local.thirty_days_in_seconds : local.fifteen_minutes_in_seconds
+  max_ttl     = local.use_prod_sizing ? local.thirty_days_in_seconds : local.fifteen_minutes_in_seconds
+  default_ttl = local.use_prod_sizing ? local.thirty_days_in_seconds : local.fifteen_minutes_in_seconds
 
   parameters_in_cache_key_and_forwarded_to_origin {
     enable_accept_encoding_brotli = true

--- a/terraform/20-app/cloud-front.public-api.tf
+++ b/terraform/20-app/cloud-front.public-api.tf
@@ -1,3 +1,7 @@
+locals {
+  one_day_in_seconds = 86400
+}
+
 module "cloudfront_public_api" {
   source  = "terraform-aws-modules/cloudfront/aws"
   version = "3.4.0"
@@ -57,15 +61,11 @@ module "cloudfront_public_api" {
     }
   }
 
-  custom_error_response = [{
-    count                 = 0
-    error_code            = 404
-    error_caching_min_ttl = local.use_prod_cloudfront_ttl ? 2592000 : 900
-  }]
   custom_error_response = [
     {
       count                 = 0
       error_code            = 404
+      error_caching_min_ttl = local.use_prod_sizing ? local.thirty_days_in_seconds : local.one_day_in_seconds
     }
   ]
 
@@ -94,9 +94,9 @@ resource "aws_cloudfront_origin_request_policy" "public_api" {
 resource "aws_cloudfront_cache_policy" "public_api" {
   name = "${local.prefix}-public-api"
 
-  min_ttl     = local.use_prod_cloudfront_ttl ? 2592000 : 900
-  max_ttl     = local.use_prod_cloudfront_ttl ? 2592000 : 900
-  default_ttl = local.use_prod_cloudfront_ttl ? 2592000 : 900
+  min_ttl     = local.use_prod_sizing ? local.thirty_days_in_seconds : local.one_day_in_seconds
+  max_ttl     = local.use_prod_sizing ? local.thirty_days_in_seconds : local.one_day_in_seconds
+  default_ttl = local.use_prod_sizing ? local.thirty_days_in_seconds : local.one_day_in_seconds
 
   parameters_in_cache_key_and_forwarded_to_origin {
     cookies_config {

--- a/terraform/20-app/cloud-front.public-api.tf
+++ b/terraform/20-app/cloud-front.public-api.tf
@@ -50,7 +50,7 @@ module "cloudfront_public_api" {
     target_origin_id           = "alb"
     use_forwarded_values       = false
     viewer_protocol_policy     = "redirect-to-https"
-    function_association = {
+    function_association       = {
       viewer-request = {
         function_arn = aws_cloudfront_function.public_api_viewer_request.arn
       }
@@ -62,6 +62,12 @@ module "cloudfront_public_api" {
     error_code            = 404
     error_caching_min_ttl = local.use_prod_cloudfront_ttl ? 2592000 : 900
   }]
+  custom_error_response = [
+    {
+      count                 = 0
+      error_code            = 404
+    }
+  ]
 
   logging_config = {
     bucket          = data.aws_s3_bucket.cloud_front_logs_eu_west_2.bucket_domain_name

--- a/terraform/20-app/locals.tf
+++ b/terraform/20-app/locals.tf
@@ -48,4 +48,6 @@ locals {
     public_api       = "${local.environment}-api.${local.account_layer.dns.account.dns_name}"
     public_api_lb    = "${local.environment}-api-lb.${local.account_layer.dns.account.dns_name}"
   }
+
+  thirty_days_in_seconds = 2592000
 }

--- a/terraform/20-app/locals.tf
+++ b/terraform/20-app/locals.tf
@@ -10,8 +10,6 @@ locals {
 
   use_prod_sizing = contains(["perf", "train", "uat", "prod"], local.environment)
 
-  use_prod_cloudfront_ttl = false
-
   wke = {
     account = ["dev", "test", "uat", "prod"]
     other   = ["pen", "perf", "train"]


### PR DESCRIPTION
- Applies the prod setting for cloudfront TTLs in the public API and FE distributions
- In prod-like envs, TTL is 30 days is set for both
- In dev-like envs, TTL is 1 day for public API and 15 mins for the FE