### PR TITLE
Task/bypass timeouts when flushing caches/cdd 1882

### DIFF
--- a/scripts/_cache.sh
+++ b/scripts/_cache.sh
@@ -50,6 +50,8 @@ function _cache_flush() {
 
     echo "Filling the public api cloud front cache..." 
     uhd cache fill-public-api --wait
+
+    _supress_cache_flush_timeout_exit_code
 }
 
 function _cache_flush_redis() {
@@ -155,4 +157,12 @@ function _get_distribution_id() {
     local distribution_id=$(jq -r --arg distribution "$distribution" '.cloud_front.value[$distribution]' $terraform_output_file)
 
     echo $distribution_id
+}
+
+function _supress_cache_flush_timeout_exit_code() {
+    local exit_code=$?
+    if [[ $exit_code = 255 ]]; then
+      echo "Not waiting for cache fill to complete..."
+      return 0
+    fi
 }

--- a/scripts/_cache.sh
+++ b/scripts/_cache.sh
@@ -51,7 +51,11 @@ function _cache_flush() {
     echo "Filling the public api cloud front cache..." 
     uhd cache fill-public-api --wait
 
-    _supress_cache_flush_timeout_exit_code
+    local exit_code=$?
+    if [[ $exit_code = 255 ]]; then
+      echo "Not waiting for cache fill to complete..."
+      return 0
+    fi
 }
 
 function _cache_flush_redis() {
@@ -157,12 +161,4 @@ function _get_distribution_id() {
     local distribution_id=$(jq -r --arg distribution "$distribution" '.cloud_front.value[$distribution]' $terraform_output_file)
 
     echo $distribution_id
-}
-
-function _supress_cache_flush_timeout_exit_code() {
-    local exit_code=$?
-    if [[ $exit_code = 255 ]]; then
-      echo "Not waiting for cache fill to complete..."
-      return 0
-    fi
 }


### PR DESCRIPTION
Supress exit code 255 timeout that happens we flush the public API cache at the end of the cache flush process.
This is currently resulting in a false negative whereby the task is still running behind the scenes.