### PR TITLE
Remove cloudfront legacy redirect & associated DNS name for `train` environment only

### DIFF
--- a/terraform/20-app/cloud-front.legacy-dashboard-redirect.tf
+++ b/terraform/20-app/cloud-front.legacy-dashboard-redirect.tf
@@ -2,6 +2,8 @@ module "cloudfront_legacy_dashboard_redirect" {
   source  = "terraform-aws-modules/cloudfront/aws"
   version = "3.4.0"
 
+  create_distribution = local.environment != "train"
+
   aliases             = [local.dns_names.legacy_dashboard]
   comment             = "${local.prefix}-legacy-dashboard-redirect"
   enabled             = true

--- a/terraform/20-app/route-53.legacy-dashboard-redirect.tf
+++ b/terraform/20-app/route-53.legacy-dashboard-redirect.tf
@@ -2,6 +2,8 @@ module "route_53_records_legacy_dashboard_redirect" {
   source  = "terraform-aws-modules/route53/aws//modules/records"
   version = "2.10.2"
 
+  create = local.environment != "train"
+
   zone_id = local.account_layer.dns.legacy.zone_id
 
   records = [
@@ -20,7 +22,7 @@ module "route_53_records_legacy_dashboard_redirect_wke_account" {
   source  = "terraform-aws-modules/route53/aws//modules/records"
   version = "2.10.2"
 
-  create  = contains(local.wke.account, local.environment)
+  create  = contains(local.wke.account, local.environment) && local.environment != "train"
   zone_id = local.account_layer.dns.legacy.zone_id
 
   records = [


### PR DESCRIPTION
The legacy dashboard CF distribution currently points to an account-level resource for well known environments. 
This is fine for the most part, except the UAT account, which has 2 well known-environments in. 

Which was causing a name clash when the `uat` and `train` envs try to create their CF distributions.

The `train` environment doesn't get a whole lot of traffic and it doesn't seem like the `train` subdomain for the covid dash even exists as far as I can tell, so for now I'm gonna just remove the problematic cloudfront redirect. 
**This is very much being done as a quick fix.**

The alternative would have been to redo a lot of the work Kev did so that we can point the redirect at the environment level resource instead. Which seemed like more effort than it would be worth in the short-medium term.
I'll catch up with @kevinkuszyk when he's back from hols as to why this assumption of pointing to an account-level resource was made for the well known envs. There is probs some context I'm missing here.