### PR TITLE
Task/increase ci aws role duration/cdd 1928

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -9,6 +9,9 @@ inputs:
   aws-region:
     description: "The AWS region to configure credentials in."
     required: true
+  role-duration-seconds:
+    description: "The assumed role duration in seconds. Defaults to 1 hour."
+    default: "3600"
 
   # Note that the roles are optional by default.
   # When using this composite action, you must pass in the role you need
@@ -38,6 +41,7 @@ runs:
       with:
         role-to-assume: ${{ inputs.tools-account-role }}
         aws-region: ${{ inputs.aws-region }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for prod account
       uses: aws-actions/configure-aws-credentials@v4
@@ -46,6 +50,7 @@ runs:
         role-to-assume: ${{ inputs.prod-account-role }}
         aws-region: ${{ inputs.aws-region }}
         role-chaining: true
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for dev account
       uses: aws-actions/configure-aws-credentials@v4
@@ -54,6 +59,7 @@ runs:
         role-to-assume: ${{ inputs.dev-account-role }}
         aws-region: ${{ inputs.aws-region }}
         role-chaining: true
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for test account
       uses: aws-actions/configure-aws-credentials@v4
@@ -62,6 +68,7 @@ runs:
         role-to-assume: ${{ inputs.test-account-role }}
         aws-region: ${{ inputs.aws-region }}
         role-chaining: true
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for uat account
       uses: aws-actions/configure-aws-credentials@v4
@@ -70,3 +77,4 @@ runs:
         role-to-assume: ${{ inputs.uat-account-role }}
         aws-region: ${{ inputs.aws-region }}
         role-chaining: true
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}

--- a/.github/workflows/cleanup-ci-test-environments.yml
+++ b/.github/workflows/cleanup-ci-test-environments.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           aws-region: ${{ env.AWS_REGION }}
           tools-account-role: ${{ secrets.UHD_TERRAFORM_ROLE }}
+          # Timeout after 6 hours
+          role-duration-seconds: "21600"
 
       - name: Terraform cleanup
         run: |


### PR DESCRIPTION
This PR does the following:

- Allows for overriding the timeout of the AWS role duration. Defaults to 1 hour
- Allows the CI cleanup cronjob to login with the role set to a limit of 6 hours. This should allow multiple envs to be cleaned up before the start of the working day. Note that the cronjob runs at midnight every weeknight, so can now in theory keep running until 6am.