### PR TITLE
chore: rename unleash env vars

### DIFF
--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -43,8 +43,8 @@ module "ecs_service_front_end" {
           value = local.urls.private_api
         },
         {
-          name  = "UNLEASH_URL"
-          value = local.urls.feature_flags
+          name  = "UNLEASH_SERVER_API_URL"
+          value = "${local.urls.feature_flags}/api"
         },
         {
           name  = "FEEDBACK_API_URL"
@@ -65,7 +65,7 @@ module "ecs_service_front_end" {
           valueFrom = "${aws_secretsmanager_secret.google_analytics_credentials.arn}:google_tag_manager_id::"
         },
         {
-          name      = "FEATURE_FLAGS_API_KEY",
+          name      = "UNLEASH_SERVER_API_TOKEN",
           valueFrom = "${aws_secretsmanager_secret.feature_flags_api_keys.arn}:client_api_key::"
         }
       ]


### PR DESCRIPTION
Renames the unleash env vars to match what the unleash SDK expects