### PR TITLE
Set aurora db cluster to be primary and manage main password in secrets manager

### DIFF
--- a/terraform/20-app/aurora-db.app.tf
+++ b/terraform/20-app/aurora-db.app.tf
@@ -9,9 +9,7 @@ module "aurora_db_app" {
   backup_retention_period = 35
   kms_key_id              = module.kms_app_rds.key_arn
 
-  is_primary_cluster            = false
-  replication_source_identifier = aws_db_instance.app_rds_primary.arn
-  manage_master_user_password   = false
+  manage_master_user_password   = true
   database_name                 = "cms"
 
   monitoring_interval = 0


### PR DESCRIPTION
Once the aurora replica clusters have been promoted out of the existing RDS clusters, they  can be switched to be primary.
As such it no longer needs to replicate from the RDS.
Also sets the password to be managed and rotated automatically in secrets manager as we were doing before with RDS