### PR TITLE
Task/rollout aurora db part six switch cms admin to aurora db/cdd 1750

### DIFF
--- a/terraform/20-app/ecs.service.cms-admin.tf
+++ b/terraform/20-app/ecs.service.cms-admin.tf
@@ -44,11 +44,11 @@ module "ecs_service_cms_admin" {
         },
         {
           name  = "POSTGRES_DB"
-          value = local.rds.app.primary.db_name
+          value = module.aurora_db_app.cluster_database_name
         },
         {
           name  = "POSTGRES_HOST"
-          value = local.rds.app.primary.address
+          value = module.aurora_db_app.cluster_endpoint
         },
         {
           name  = "APIENV"
@@ -58,11 +58,11 @@ module "ecs_service_cms_admin" {
       secrets = [
         {
           name      = "POSTGRES_USER"
-          valueFrom = "${local.main_db_password_secret_arn}:username::"
+          valueFrom = "${local.main_db_aurora_password_secret_arn}:username::"
         },
         {
           name      = "POSTGRES_PASSWORD"
-          valueFrom = "${local.main_db_password_secret_arn}:password::"
+          valueFrom = "${local.main_db_aurora_password_secret_arn}:password::"
         },
         {
           name      = "SECRET_KEY",

--- a/terraform/20-app/locals.tf
+++ b/terraform/20-app/locals.tf
@@ -67,5 +67,6 @@ locals {
   thirty_days_in_seconds  = 2592000
   five_minutes_in_seconds = 300
 
-  main_db_password_secret_arn = aws_secretsmanager_secret.temporary_main_db_credentials.arn
+  main_db_aurora_password_secret_arn = module.aurora_db_app.cluster_master_user_secret[0]["secret_arn"]
+  main_db_password_secret_arn        = aws_secretsmanager_secret.temporary_main_db_credentials.arn
 }


### PR DESCRIPTION
Canary approach here. Pointing the CMS admin at the aurora db cluster first. It's not seen by users and takes the least amount of traffic so I'm checking to make sure everything here is okay before switching the remaining workloads over