### PR TITLE
Include `uhd-<env>-temporary-main-db-credentials` in `uhd secrets delete-all-secrets <env>` command

### DIFF
--- a/scripts/_secrets.sh
+++ b/scripts/_secrets.sh
@@ -54,7 +54,8 @@ function _delete_all_secrets() {
                 "uhd-${env}-google-analytics-credentials"
                 "uhd-${env}-aurora-db-feature-flags-credentials"
                 "uhd-${env}-feature-flags-admin-user-credentials"
-                "uhd-${env}-feature-flags-api-keys")
+                "uhd-${env}-feature-flags-api-keys"
+                "uhd-${env}-temporary-main-db-credentials")
 
     for ((i=1; i<=${#secret_ids[@]}; ++i)); do
         _delete_secret "${secret_ids[i]}"


### PR DESCRIPTION
Because of some limitations with AWS, I was forced to switch RDS back to using a static self-managed secret in Secrets Manager to allow the aurora replica to be attached to the primary RDS.
Now that is all done and dusted, the temporary secret has been removed elsewhere. But it may still be hanging around for dev environments that are a bit behind.
So this PR deletes that secret if its there for now. We can remove this a bit further down the line when needed