### PR TITLE
Bug/front end cannot reach feature flags api container add additional auth/cdd 1952

### DIFF
--- a/terraform/20-app/api-keys.tf
+++ b/terraform/20-app/api-keys.tf
@@ -31,6 +31,15 @@ resource "random_password" "feature_flags_client_api_key" {
   upper       = false
 }
 
+resource "random_password" "feature_flags_x_auth" {
+  length      = 30
+  min_numeric = 1
+  min_lower   = 1
+  min_upper   = 1
+  special     = false
+  upper       = false
+}
+
 resource "random_password" "feature_flags_admin_user_password" {
   length      = 20
   min_numeric = 1
@@ -41,6 +50,7 @@ resource "random_password" "feature_flags_admin_user_password" {
 }
 
 locals {
+  feature_flags_x_auth         = random_password.feature_flags_x_auth.result
   feature_flags_client_api_key = "*:production.${random_password.feature_flags_client_api_key.result}"
   private_api_key              = "${random_password.private_api_key_prefix.result}.${random_password.private_api_key_suffix.result}"
 }

--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -67,6 +67,10 @@ module "ecs_service_front_end" {
         {
           name      = "UNLEASH_SERVER_API_TOKEN",
           valueFrom = "${aws_secretsmanager_secret.feature_flags_api_keys.arn}:client_api_key::"
+        },
+        {
+          name      = "FEATURE_FLAGS_AUTH_KEY",
+          valueFrom = "${aws_secretsmanager_secret.feature_flags_api_keys.arn}:x_auth::"
         }
       ]
     }

--- a/terraform/20-app/secret-manager.tf
+++ b/terraform/20-app/secret-manager.tf
@@ -28,6 +28,7 @@ resource "aws_secretsmanager_secret_version" "feature_flags_api_keys" {
   secret_id     = aws_secretsmanager_secret.feature_flags_api_keys.id
   secret_string = jsonencode({
     client_api_key = local.feature_flags_client_api_key
+    x_auth         = local.feature_flags_x_auth
   })
 }
 


### PR DESCRIPTION
This PR does the following:

- Enforces another header on the feature flags alb called `x-auth`
- Injects this key into the frontend containers as the env var `FEATURE_FLAGS_AUTH_KEY`

This means all requests made to the feature flags service must include the `x-auth` header