### PR TITLE
Point utility worker used by bootstrap job at aurora primary node

### DIFF
--- a/terraform/20-app/ecs-jobs/bootstrap-env.tftpl
+++ b/terraform/20-app/ecs-jobs/bootstrap-env.tftpl
@@ -17,7 +17,12 @@
         "command": [
           "scripts/boot.sh",
           "${cms_admin_user_password}"
-        ]
+        ],
+        "environment": [
+        {
+          "name": "POSTGRES_HOST",
+          "value": "${aurora_writer_endpoint}"
+        }
       }
     ]
   },

--- a/terraform/20-app/ecs-jobs/bootstrap-env.tftpl
+++ b/terraform/20-app/ecs-jobs/bootstrap-env.tftpl
@@ -23,8 +23,9 @@
           "name": "POSTGRES_HOST",
           "value": "${aurora_writer_endpoint}"
         }
-      }
-    ]
-  },
+      ]
+     }
+   ]
+ },
   "taskDefinition": "${task_arn}"
 }

--- a/terraform/20-app/ecs.jobs.bootstrap-env.tf
+++ b/terraform/20-app/ecs.jobs.bootstrap-env.tf
@@ -1,7 +1,8 @@
 resource "local_sensitive_file" "ecs_job_bootstrap_env" {
   filename = "ecs-jobs/bootstrap-env.json"
-  content = templatefile("ecs-jobs/bootstrap-env.tftpl", {
+  content  = templatefile("ecs-jobs/bootstrap-env.tftpl", {
     cms_admin_user_password = random_password.cms_admin_user_password.result
+    aurora_writer_endpoint  = local.aurora.app.primary.address
     cluster_arn             = module.ecs.cluster_arn
     security_group_id       = module.ecs_service_utility_worker.security_group_id
     subnet_ids              = module.vpc.private_subnets


### PR DESCRIPTION
The bootrstrap job useds the utility worker which points to the db node used by the private API replica, at least the variable that was previously dedicated for it.

For non-prod envs this is fine because there is only 1 db node i,e. the primary but when its prod-grade envs like perf then its pointed to a reader/secondary replica i.e. read-only. So the write transaction will fail.

This PR overrides the env var to point to the aurora primary