### PR TITLE
Task/add synthetic canary for front end/cdd 2109

### DIFF
--- a/terraform/20-app/.terraform.lock.hcl
+++ b/terraform/20-app/.terraform.lock.hcl
@@ -1,9 +1,30 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.4.2"
+  hashes = [
+    "h1:1eOz9vM/55vnQjxk23RhnYga7PZq8n2rGxG+2Vx2s6w=",
+    "h1:G4v6F6Lhqlo3EKGBKEK/kJRhNcQiRrhEdUiVpBHKHOA=",
+    "h1:WfIjVbYA9s/uN2FwhGoiffT7CLFydy7MT1waFbt9YrY=",
+    "zh:08faed7c9f42d82bc3d406d0d9d4971e2d1c2d34eae268ad211b8aca57b7f758",
+    "zh:3564112ed2d097d7e0672378044a69b06642c326f6f1584d81c7cdd32ebf3a08",
+    "zh:53cd9afd223c15828c1916e68cb728d2be1cbccb9545568d6c2b122d0bac5102",
+    "zh:5ae4e41e3a1ce9d40b6458218a85bbde44f21723943982bca4a3b8bb7c103670",
+    "zh:5b65499218b315b96e95c5d3463ea6d7c66245b59461217c99eaa1611891cd2c",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7f45b35a8330bebd184c2545a41782ff58240ed6ba947274d9881dd5da44b02e",
+    "zh:87e67891033214e55cfead1391d68e6a3bf37993b7607753237e82aa3250bb71",
+    "zh:de3590d14037ad81fc5cedf7cfa44614a92452d7b39676289b704a962050bc5e",
+    "zh:e7e6f2ea567f2dbb3baa81c6203be69f9cd6aeeb01204fd93e3cf181e099b610",
+    "zh:fd24d03c89a7702628c2e5a3c732c0dede56fa75a08da4a1efe17b5f881c88e2",
+    "zh:febf4b7b5f3ff2adff0573ef6361f09b6638105111644bdebc0e4f575373935f",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.58.0"
-  constraints = ">= 3.29.0, >= 3.74.0, >= 4.66.1, >= 5.0.0, >= 5.12.0, >= 5.25.0, >= 5.27.0, >= 5.30.0, >= 5.32.0, >= 5.37.0, >= 5.46.0, >= 5.49.0, >= 5.53.0, >= 5.58.0, 5.58.0"
+  constraints = ">= 3.29.0, >= 3.74.0, >= 4.0.0, >= 4.66.1, >= 5.0.0, >= 5.12.0, >= 5.25.0, >= 5.27.0, >= 5.30.0, >= 5.32.0, >= 5.37.0, >= 5.46.0, >= 5.49.0, >= 5.53.0, >= 5.58.0, 5.58.0"
   hashes = [
     "h1:6vsFc7SmmlElqg3k0X6azrO0yarM7UPCUF4XsAYryjA=",
     "h1:XnAwb/MGeP7sxz/0SKLQF1ujaP7Bg15ol+ca7KZruio=",

--- a/terraform/20-app/s3.canary-logs.tf
+++ b/terraform/20-app/s3.canary-logs.tf
@@ -1,0 +1,24 @@
+module "s3_canary_logs" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "4.1.2"
+
+  bucket = "${local.prefix}-canary-logs"
+
+  attach_deny_insecure_transport_policy = true
+  force_destroy                         = true
+
+  logging = {
+    target_bucket = data.aws_s3_bucket.s3_access_logs.id
+    target_prefix = "${local.prefix}-canary-logs/"
+  }
+
+  lifecycle_rule = [
+    {
+      id      = "all"
+      enabled = true
+      expiration = {
+        days = 7
+      }
+    }
+  ]
+}

--- a/terraform/modules/cloud-watch-canary/cloudwatch.synthetics-canary.tf
+++ b/terraform/modules/cloud-watch-canary/cloudwatch.synthetics-canary.tf
@@ -1,0 +1,18 @@
+resource "aws_synthetics_canary" "this" {
+  name                 = var.name
+  artifact_s3_location = "s3://${var.s3_logs_destination.bucket_id}"
+  execution_role_arn   = module.iam_canary_role.iam_role_arn
+  zip_file             = data.archive_file.canary_script.output_path
+  handler              = "index.handler"
+  runtime_version      = "syn-nodejs-puppeteer-8.0"
+  start_canary         = true
+
+  schedule {
+    expression = var.schedule_expression
+  }
+
+  vpc_config {
+    subnet_ids         = var.subnet_ids
+    security_group_ids = [module.canary_security_group.security_group_id]
+  }
+}

--- a/terraform/modules/cloud-watch-canary/cloudwatch.synthetics-canary.tf
+++ b/terraform/modules/cloud-watch-canary/cloudwatch.synthetics-canary.tf
@@ -6,6 +6,7 @@ resource "aws_synthetics_canary" "this" {
   handler              = "index.handler"
   runtime_version      = "syn-nodejs-puppeteer-8.0"
   start_canary         = true
+  delete_lambda        = true
 
   schedule {
     expression = var.schedule_expression

--- a/terraform/modules/cloud-watch-canary/iam.tf
+++ b/terraform/modules/cloud-watch-canary/iam.tf
@@ -1,0 +1,57 @@
+module "iam_canary_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.40.0"
+
+  create_role          = true
+  max_session_duration = 3600
+  role_name            = var.name
+  role_requires_mfa    = false
+
+  custom_role_policy_arns = [module.iam_canary_policy.arn]
+  trusted_role_services   = ["lambda.amazonaws.com"]
+}
+
+module "iam_canary_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.40.0"
+
+  create_policy = true
+  name          = var.name
+
+  policy = jsonencode(
+    {
+      Version   = "2012-10-17",
+      Statement = [
+        {
+          Action   = ["s3:PutObject"],
+          Effect   = "Allow",
+          Resource = ["${var.s3_logs_destination.bucket_arn}/*"]
+        },
+        {
+          Action   = ["s3:ListAllMyBuckets"],
+          Effect   = "Allow",
+          Resource = ["*"]
+        },
+        {
+          Action   = ["cloudwatch:PutMetricData"],
+          Effect   = "Allow",
+          Resource = ["*"],
+          Condition = {
+            StringEquals = {
+              "cloudwatch:namespace" = "CloudWatchSynthetics"
+            }
+          }
+        },
+        {
+          Action = [
+            "ec2:CreateNetworkInterface",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DeleteNetworkInterface",
+          ]
+          Effect   = "Allow",
+          Resource = ["*"],
+        }
+      ]
+    }
+  )
+}

--- a/terraform/modules/cloud-watch-canary/script.tf
+++ b/terraform/modules/cloud-watch-canary/script.tf
@@ -1,0 +1,13 @@
+locals {
+  file_content = file(var.script_path)
+  zip          = "builds/${var.name}-${sha256(local.file_content)}.zip"
+}
+
+data "archive_file" "canary_script" {
+  type        = "zip"
+  output_path = local.zip
+  source {
+    content  = local.file_content
+    filename = "nodejs/node_modules/index.js"
+  }
+}

--- a/terraform/modules/cloud-watch-canary/security-group.tf
+++ b/terraform/modules/cloud-watch-canary/security-group.tf
@@ -1,0 +1,15 @@
+module "canary_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name   = var.name
+  vpc_id = var.vpc_id
+
+  egress_with_cidr_blocks = [
+    {
+      description = "https to internet"
+      rule        = "https-443-tcp"
+      cidr_blocks = "0.0.0.0/0"
+    }
+  ]
+}

--- a/terraform/modules/cloud-watch-canary/vars.tf
+++ b/terraform/modules/cloud-watch-canary/vars.tf
@@ -1,0 +1,40 @@
+variable "create" {
+  description = "Whether to create the synthetic canary and its associated components"
+  type        = bool
+  default     = false
+}
+
+variable "name" {
+  description = "The name to associate with the synthetic canary components"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC to deploy the canary within"
+  type        = string
+}
+
+variable "s3_access_logs_id" {
+  description = "The ID of the S3 bucket where access logs are sent to"
+  type        = string
+}
+
+variable "s3_logs_destination" {
+  description = "Map containing the ID and the ARN of the S3 bucket where the results of the canary are to be sent."
+  type        = map(string)
+}
+
+variable "subnet_ids" {
+  description = "The IDs of the subnets where this canary is to run."
+  type        = list(string)
+}
+
+variable "schedule_expression" {
+  description = "The cron schedule expression to apply to the canary."
+  type        = string
+}
+
+variable "script_path" {
+  description = "The file path of the script to attach to the canary"
+  type        = string
+}

--- a/terraform/modules/cloud-watch-canary/vars.tf
+++ b/terraform/modules/cloud-watch-canary/vars.tf
@@ -1,7 +1,7 @@
 variable "create" {
   description = "Whether to create the synthetic canary and its associated components"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "name" {

--- a/terraform/modules/cloud-watch-canary/versions.tf
+++ b/terraform/modules/cloud-watch-canary/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.58.0"
+    }
+  }
+}


### PR DESCRIPTION
This module will be used as follows:
```
module "cloudwatch_canary_front_end" {
  source            = "../modules/cloud-watch-canary"
  name              = "${local.prefix}-frontend"
  vpc_id            = module.vpc.vpc_id
  s3_access_logs_id = data.aws_s3_bucket.s3_access_logs.id
  s3_logs_destination = {
    bucket_id  = module.s3_canary_logs.s3_bucket_id
    bucket_arn = module.s3_canary_logs.s3_bucket_arn
  }
  subnet_ids          = module.vpc.private_subnets
  schedule_expression = "rate(0 minute)"
  script_path         = "../../src/canary-front-end/index.js"
}

```