### PR TITLE
s3 ingest bucket lifecycle rule for stale `in/` files

### DIFF
--- a/terraform/20-app/s3.ingest.tf
+++ b/terraform/20-app/s3.ingest.tf
@@ -36,6 +36,16 @@ module "s3_ingest" {
       expiration = {
         days = 14
       }
+    },
+    {
+      id      = "stale"
+      enabled = true
+      filter = {
+        prefix = "in/"
+      }
+      expiration = {
+        days = 2
+      }
     }
   ]
 }


### PR DESCRIPTION
Delete files with `in/` prefix from ingest bucket after 2 days. We expect these to be processed within minutes, so these are considered 'dead' files