### PR TITLE
Add IAM role for terraform to assume

### DIFF
--- a/terraform/10-account/iam.terraform-role.tf
+++ b/terraform/10-account/iam.terraform-role.tf
@@ -1,0 +1,16 @@
+module "iam_terraform_role" {
+  source      = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version     = "5.44.0"
+  create_role = true
+
+  role_name         = "TerraformOperator"
+  role_requires_mfa = false
+
+  custom_role_policy_arns = [
+    "arn:aws:iam::aws:policy/AdministratorAccess",
+  ]
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.tools_account_id}:root",
+  ]
+}


### PR DESCRIPTION
This PR adds an IAM role for terraform to assume. Currently there is a role in each account, but they are not managed by terraform, they were handrolled/click-opped into place.

The change will need to be phased because the role needs to be there for terraform to assume. The next step will be to adjust the `assume_role` variable to point to this new role instead.