### PR TITLE
Reference application container images via data source `aws_ecr_image` for most recent image instead of by `latest` tag

### DIFF
--- a/terraform/20-app/ecr.tf
+++ b/terraform/20-app/ecr.tf
@@ -41,6 +41,11 @@ module "ecr_front_end" {
   repository_lifecycle_policy = local.standard_ecr_lifecycle_policy
 }
 
+data "aws_ecr_image" "front_end" {
+  repository_name = module.ecr_front_end.repository_name
+  most_recent     = true
+}
+
 module "ecr_api" {
   source  = "terraform-aws-modules/ecr/aws"
   version = "2.2.0"
@@ -53,6 +58,11 @@ module "ecr_api" {
 
   create_lifecycle_policy     = true
   repository_lifecycle_policy = local.standard_ecr_lifecycle_policy
+}
+
+data "aws_ecr_image" "api" {
+  repository_name = module.ecr_api.repository_name
+  most_recent     = true
 }
 
 
@@ -84,4 +94,9 @@ module "ecr_ingestion" {
 
   create_lifecycle_policy     = true
   repository_lifecycle_policy = local.standard_ecr_lifecycle_policy
+}
+
+data "aws_ecr_image" "ingestion" {
+  repository_name = module.ecr_ingestion.repository_name
+  most_recent     = true
 }

--- a/terraform/20-app/ecs.service.cms-admin.tf
+++ b/terraform/20-app/ecs.service.cms-admin.tf
@@ -29,7 +29,7 @@ module "ecs_service_cms_admin" {
       memory                                 = local.use_prod_sizing ? 4096 : 1024
       essential                              = true
       readonly_root_filesystem               = false
-      image                                  = "${module.ecr_api.repository_url}:latest-graviton"
+      image                                  = data.aws_ecr_image.api.image_uri
       port_mappings                          = [
         {
           containerPort = 80

--- a/terraform/20-app/ecs.service.feedback-api.tf
+++ b/terraform/20-app/ecs.service.feedback-api.tf
@@ -29,7 +29,7 @@ module "ecs_service_feedback_api" {
       memory                                 = local.use_prod_sizing ? 2048 : 1024
       essential                              = true
       readonly_root_filesystem               = false
-      image                                  = "${module.ecr_api.repository_url}:latest-graviton"
+      image                                  = data.aws_ecr_image.api.image_uri
       port_mappings                          = [
         {
           containerPort = 80

--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -29,7 +29,7 @@ module "ecs_service_front_end" {
       memory                                 = local.use_prod_sizing ? 4096 : 1024
       essential                              = true
       readonly_root_filesystem               = false
-      image                                  = "${module.ecr_front_end.repository_url}:latest-graviton"
+      image                                  = data.aws_ecr_image.front_end.image_uri
       port_mappings                          = [
         {
           containerPort = 3000

--- a/terraform/20-app/ecs.service.private-api.tf
+++ b/terraform/20-app/ecs.service.private-api.tf
@@ -31,7 +31,7 @@ module "ecs_service_private_api" {
       memory                                 = local.use_prod_sizing ? 4096 : 1024
       essential                              = true
       readonly_root_filesystem               = false
-      image                                  = "${module.ecr_api.repository_url}:latest-graviton"
+      image                                  = data.aws_ecr_image.api.image_uri
       port_mappings                          = [
         {
           containerPort = 80

--- a/terraform/20-app/ecs.service.public-api.tf
+++ b/terraform/20-app/ecs.service.public-api.tf
@@ -29,7 +29,7 @@ module "ecs_service_public_api" {
       memory                                 = local.use_prod_sizing ? 2048 : 1024
       essential                              = true
       readonly_root_filesystem               = false
-      image                                  = "${module.ecr_api.repository_url}:latest-graviton"
+      image                                  = data.aws_ecr_image.api.image_uri
       port_mappings                          = [
         {
           containerPort = 80

--- a/terraform/20-app/ecs.service.utility-worker.tf
+++ b/terraform/20-app/ecs.service.utility-worker.tf
@@ -27,7 +27,7 @@ module "ecs_service_utility_worker" {
       memory                                 = 32768
       essential                              = true
       readonly_root_filesystem               = false
-      image                                  = "${module.ecr_api.repository_url}:latest-graviton"
+      image                                  = data.aws_ecr_image.api.image_uri
       port_mappings                          = [
         {
           containerPort = 80

--- a/terraform/20-app/lambda.ingestion.tf
+++ b/terraform/20-app/lambda.ingestion.tf
@@ -13,7 +13,7 @@ module "lambda_ingestion" {
   create_package = false
   package_type   = "Image"
   architectures  = ["arm64"]
-  image_uri      = "${module.ecr_ingestion.repository_url}:latest"
+  image_uri      = data.aws_ecr_image.ingestion.image_uri
   depends_on     = [module.ecr_ingestion.repository_arn]
 
   maximum_retry_attempts = 1


### PR DESCRIPTION
The use of the `latest` tag is to be deprecated in favour of images tagged with commit hash so that mutability is removed.

This PR switches all application workloads to reference the images via the `aws_ecr_image` data resource of most recent image instead of via the hard-coded (and mutable) tag of `latest`