### PR TITLE
Task/provide ecrs as module  /cdd 1778

### DIFF
--- a/terraform/20-app/ecr.tf
+++ b/terraform/20-app/ecr.tf
@@ -85,3 +85,28 @@ module "ecr_ingestion" {
   create_lifecycle_policy     = true
   repository_lifecycle_policy = local.standard_ecr_lifecycle_policy
 }
+
+module "ecr_front_end_ecs" {
+  source = "../modules/ecr"
+  name   = "${local.prefix}-front-end-ecs"
+
+  account_id       = var.assume_account_id
+  tools_account_id = var.tools_account_id
+}
+
+module "ecr_back_end_ecs" {
+  source = "../modules/ecr"
+  name   = "${local.prefix}-back-end-ecs"
+
+  account_id       = var.assume_account_id
+  tools_account_id = var.tools_account_id
+}
+
+module "ecr_ingestion_lambda" {
+  source = "../modules/ecr"
+  name   = "${local.prefix}-ingestion-lambda"
+
+  account_id                         = var.assume_account_id
+  tools_account_id                   = var.tools_account_id
+  repository_lambda_read_access_arns = [module.lambda_ingestion.lambda_role_arn]
+}

--- a/terraform/modules/ecr/data.aws_ecr_image.tf
+++ b/terraform/modules/ecr/data.aws_ecr_image.tf
@@ -1,0 +1,5 @@
+data "aws_ecr_image" "this" {
+  depends_on = [terraform_data.initial_image_provisioner]
+  repository_name = module.ecr.repository_name
+  most_recent     = true
+}

--- a/terraform/modules/ecr/ecr.tf
+++ b/terraform/modules/ecr/ecr.tf
@@ -1,0 +1,13 @@
+module "ecr" {
+  source  = "terraform-aws-modules/ecr/aws"
+  version = "2.2.0"
+
+  repository_force_delete           = true
+  repository_image_tag_mutability   = "IMMUTABLE"
+  repository_name                   = var.name
+  repository_read_access_arns       = ["arn:aws:iam::${var.account_id}:root"]
+  repository_read_write_access_arns = ["arn:aws:iam::${var.tools_account_id}:root"]
+
+  create_lifecycle_policy     = true
+  repository_lifecycle_policy = local.standard_ecr_lifecycle_policy
+}

--- a/terraform/modules/ecr/local.tf
+++ b/terraform/modules/ecr/local.tf
@@ -1,0 +1,18 @@
+locals {
+  standard_ecr_lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1,
+        description  = "Keep the last 30 images",
+        selection    = {
+          tagStatus   = "any",
+          countType   = "imageCountMoreThan",
+          countNumber = 30
+        },
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/modules/ecr/outputs.tf
+++ b/terraform/modules/ecr/outputs.tf
@@ -1,0 +1,3 @@
+output "image_uri" {
+  value = data.aws_ecr_image.this.image_uri
+}

--- a/terraform/modules/ecr/provisioner.initial-image.tf
+++ b/terraform/modules/ecr/provisioner.initial-image.tf
@@ -1,0 +1,11 @@
+resource "terraform_data" "initial_image_provisioner" {
+  depends_on = [module.ecr]
+  provisioner "local-exec" {
+    command = <<EOF
+      aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${var.account_id}.dkr.ecr.eu-west-2.amazonaws.com
+      docker pull alpine
+      docker tag alpine ${module.ecr.repository_url}:initial
+      docker push ${module.ecr.repository_url}:initial
+    EOF
+  }
+}

--- a/terraform/modules/ecr/vars.tf
+++ b/terraform/modules/ecr/vars.tf
@@ -1,0 +1,23 @@
+variable "name" {
+  description = "The name of the repository"
+  type        = string
+  default     = ""
+}
+
+variable "account_id" {
+  description = "The ID of the AWS account in which the ECR is being vended to."
+  type        = string
+  default     = ""
+}
+
+variable "tools_account_id" {
+  description = "The ID of the tools AWS account."
+  type        = string
+  default     = ""
+}
+
+variable "repository_lambda_read_access_arns" {
+  description = "The ARNs of the Lambda service roles that have read access to the repository"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
This PR adds the ECRs which only allow immutable tags.
The idea being we'll dual run publishing to these ECRs and when we're ready i.e. all the tooling is in place, we can switch over