### PR TITLE
Task/add docker update command/cdd 1777

### DIFF
--- a/scripts/_docker.sh
+++ b/scripts/_docker.sh
@@ -9,9 +9,10 @@ function _docker_help() {
     echo
     echo "  build [repo]           - build a docker image for the specified repo"
     echo
-    echo "  pull                 - pull the latest source images from the dev account"
-    echo "  push                 - push images to your dev ECR"
-    echo "  push <account> <env> - tag and push images"
+    echo "  pull                   - *DEPRECATED pull the latest source images from the tools account"
+    echo "  push                   - *DEPRECATED push images to your dev ECR"
+    echo "  push <account> <env>   - *DEPRECATED tag and push images"
+    echo "  update <account> <env> - pull the latest source images and push to the specified environment"
     echo
     echo "  ecr:login              - login to ECR in the tools account"
     echo "  ecr:login <account>    - login to ECR in the specified account"
@@ -26,6 +27,7 @@ function _docker() {
 
     case $verb in
         "build") _docker_build $args ;;
+        "update") _docker_update $args ;;
         "pull") _docker_pull $args ;;
         "push") _docker_push $args ;;
         "ecr:login") _docker_ecr_login $args ;;
@@ -99,6 +101,54 @@ function _docker_pull() {
          "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/data-dashboard/front-end:latest-graviton")
 
     echo $src | xargs -P10 -n1 docker pull
+}
+
+function _docker_update() {
+    local account=$1
+    local env=$2
+
+    if [[ -z ${account} ]]; then
+        echo "Account is required" >&2
+        return 1
+    fi
+
+    if [[ -z ${env} ]]; then
+        echo "Env is required" >&2
+        return 1
+    fi
+
+    uhd docker ecr:login tools
+    latest_back_end_image_tag=$(_docker_get_most_recent_back_end_image_tag)
+    latest_ingestion_image_tag=$(_docker_get_most_recent_ingestion_image_tag)
+    latest_front_end_image_tag=$(_docker_get_most_recent_front_end_image_tag)
+
+    src_account_id=$(_get_tools_account_id)
+    dest_account_id=$(_get_target_aws_account_id $account)
+
+    # Pull images from central ECRs
+    src=(
+      "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/ukhsa-data-dashboard/back-end:${latest_back_end_image_tag}"
+      "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/ukhsa-data-dashboard/ingestion:${latest_ingestion_image_tag}"
+      "${src_account_id}.dkr.ecr.eu-west-2.amazonaws.com/ukhsa-data-dashboard/front-end:${latest_front_end_image_tag}"
+    )
+
+    echo $src | xargs -P10 -n1 docker pull
+
+    # Push images to deployment ECRs
+    uhd docker ecr:login $account
+    dest=(
+      "${dest_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-back-end-ecs:${latest_back_end_image_tag}"
+      "${dest_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-ingestion-lambda:${latest_ingestion_image_tag}"
+      "${dest_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-front-end-ecs:${latest_front_end_image_tag}"
+    )
+
+    for ((i=1; i<=${#src[@]}; ++i)); do
+        docker tag "${src[i]}" "${dest[i]}"
+    done
+
+    _docker_ecr_login "tools"
+
+    echo $dest | xargs -P10 -n1 docker push
 }
 
 function _docker_push() {

--- a/scripts/_docker.sh
+++ b/scripts/_docker.sh
@@ -13,8 +13,8 @@ function _docker_help() {
     echo "  push                 - push images to your dev ECR"
     echo "  push <account> <env> - tag and push images"
     echo
-    echo "  ecr:login            - login to ECR in the dev account"
-    echo "  ecr:login <account>  - login to ECR in the specified account"
+    echo "  ecr:login              - login to ECR in the tools account"
+    echo "  ecr:login <account>    - login to ECR in the specified account"
     echo
 
     return 0

--- a/scripts/_docker.sh
+++ b/scripts/_docker.sh
@@ -5,9 +5,9 @@ function _docker_help() {
     echo "uhd docker <command> [options]"
     echo
     echo "commands:"
-    echo "  help                 - this help screen"
+    echo "  help                   - this help screen"
     echo
-    echo "  build [repo]         - build a docker image for the specified repo"
+    echo "  build [repo]           - build a docker image for the specified repo"
     echo
     echo "  pull                 - pull the latest source images from the dev account"
     echo "  push                 - push images to your dev ECR"


### PR DESCRIPTION
Adds the following command to the CLI tooling:

```
uhd docker update <account> <env>
```

As mentioned in https://github.com/UKHSA-Internal/data-dashboard-infra/pull/976 
we can no longer seperate the pull and push commands without passing the image tags between those commands.
This is because there would be a race condition of what the most recent tag is in process between the pull and push commands being called.