### PR TITLE
Task/update lambda cli tooling for deploying immutable tag images/cdd 1778

### DIFF
--- a/scripts/_docker.sh
+++ b/scripts/_docker.sh
@@ -5,17 +5,23 @@ function _docker_help() {
     echo "uhd docker <command> [options]"
     echo
     echo "commands:"
-    echo "  help                   - this help screen"
+    echo "  help                                 - this help screen"
     echo
-    echo "  build [repo]           - build a docker image for the specified repo"
+    echo "  build [repo]                         - build a docker image for the specified repo"
     echo
     echo "  pull                   - *DEPRECATED pull the latest source images from the tools account"
     echo "  push                   - *DEPRECATED push images to your dev ECR"
     echo "  push <account> <env>   - *DEPRECATED tag and push images"
     echo "  update <account> <env> - pull the latest source images and push to the specified environment"
+    echo "  pull                                 - *DEPRECATED pull the latest source images from the tools account"
+    echo "  push                                 - *DEPRECATED push images to your dev ECR"
+    echo "  push <account> <env>                 - *DEPRECATED tag and push images"
     echo
-    echo "  ecr:login              - login to ECR in the tools account"
-    echo "  ecr:login <account>    - login to ECR in the specified account"
+    echo "  update <account> <env>               - pull the latest source images and push to the specified environment"
+    echo
+    echo
+    echo "  ecr:login                            - login to ECR in the tools account"
+    echo "  ecr:login <account>                  - login to ECR in the specified account"
     echo
 
     return 0

--- a/scripts/_lambda.sh
+++ b/scripts/_lambda.sh
@@ -7,7 +7,8 @@ function _lambda_help() {
     echo "commands:"
     echo "  help                      - this help screen"
     echo 
-    echo "  redeploy-functions        - redeploy all the lambda functions"
+    echo "  redeploy-functions        - *DEPRECATED redeploy all the lambda functions"
+    echo "  restart-functions         - restarts all the lambda functions, pulling most recent images in the process"
     echo "  logs <env> <lambda name>  - tail logs for the specified lambda"
 
     return 0
@@ -19,6 +20,7 @@ function _lambda() {
 
     case $verb in
         "redeploy-functions") _lambda_redeploy_functions $args ;;
+        "restart-functions") _lambda_restart_functions $args ;;
         "logs") _lambda_logs $args ;;
 
         *) _lambda_help ;;
@@ -42,6 +44,7 @@ function _lambda_logs() {
    aws logs tail "/aws/lambda/uhd-${env}-${lambda_name}" --follow
 }
 
+# DEPRECATED
 function _lambda_redeploy_functions() {
     local ingestion_image_uri=$(_get_ingestion_image_uri)
     local ingestion_lambda_arn=$(_get_ingestion_lambda_arn)
@@ -58,6 +61,33 @@ function _lambda_redeploy_functions() {
     aws lambda wait function-updated-v2 --function-name $ingestion_lambda_arn
 }
 
+function _lambda_restart_functions() {
+    local ingestion_image_uri=$(_get_most_recent_ingestion_image_uri)
+    local ingestion_lambda_arn=$(_get_ingestion_lambda_arn)
+
+    echo "Deploying latest image to ingestion lambda..."
+    aws lambda update-function-code \
+        --function-name $ingestion_lambda_arn \
+        --image-uri $ingestion_image_uri \
+        --no-cli-pager \
+        --no-cli-auto-prompt \
+        > /dev/null
+
+    echo "Waiting for lambda to update..."
+    aws lambda wait function-updated-v2 --function-name $ingestion_lambda_arn
+}
+
+function _get_most_recent_ingestion_image_uri() {
+    local terraform_output_file=terraform/20-app/output.json
+    local ingestion_ecr_name=$(jq -r '.ecr.value.repo_names.ingestion'  $terraform_output_file)
+    local ingestion_ecr_url=$(jq -r '.ecr.value.repo_urls.ingestion'  $terraform_output_file)
+
+    most_recent_ingestion_image_tag=$(uhd docker get-recent-tag ${ingestion_ecr_name})
+    ingestion_image_uri="${ingestion_ecr_url}:${most_recent_ingestion_image_tag}"
+    echo ${ingestion_image_uri}
+}
+
+# DEPRECATED
 function _get_ingestion_image_uri() {
     local terraform_output_file=terraform/20-app/output.json
     local ingestion_image_uri=$(jq -r '.ecr.value.ingestion_image_uri'  $terraform_output_file)

--- a/terraform/20-app/lambda.ingestion.tf
+++ b/terraform/20-app/lambda.ingestion.tf
@@ -13,8 +13,8 @@ module "lambda_ingestion" {
   create_package = false
   package_type   = "Image"
   architectures  = ["arm64"]
-  image_uri      = "${module.ecr_ingestion.repository_url}:latest"
-  depends_on     = [module.ecr_ingestion.repository_arn]
+  image_uri      = module.ecr_ingestion_lambda.image_uri
+  depends_on     = [module.ecr_ingestion_lambda.repo_arn]
 
   maximum_retry_attempts = 1
   timeout                = 60 # Timeout after 1 minute

--- a/terraform/20-app/outputs.tf
+++ b/terraform/20-app/outputs.tf
@@ -58,7 +58,12 @@ output "s3" {
 
 output "ecr" {
   value = {
-    ingestion_image_uri = "${module.ecr_ingestion.repository_url}:latest"
+    repo_names = {
+      ingestion = module.ecr_ingestion_lambda.repo_name
+    }
+    repo_urls = {
+      ingestion = module.ecr_ingestion_lambda.repo_url
+    }
   }
 }
 

--- a/terraform/modules/ecr/outputs.tf
+++ b/terraform/modules/ecr/outputs.tf
@@ -1,3 +1,15 @@
 output "image_uri" {
   value = data.aws_ecr_image.this.image_uri
 }
+
+output "repo_name" {
+  value = module.ecr.repository_name
+}
+
+output "repo_url" {
+  value = module.ecr.repository_url
+}
+
+output "repo_arn" {
+  value = module.ecr.repository_arn
+}


### PR DESCRIPTION
Adds a new command -> `uhd lambda redeploy-functions` which will pull the most recent ingestion image from the immutable-tag based ECR and deploy. This will soon replace usage of `uhd lambda redeploy-functions`.

Adds a new command -> `uhd docker get-recent-tag <ecr-repo> <!account>` which will get the tag for the most recent image in a given ECR, if the account ID is not provided, then the default/current account is applied.

Removes the now redundant `ingestion_image_uri` output

Points the ingestion lambda at the data source which references the new immutable tag based ECR