### PR TITLE
Task/amend cli tooling for building custom images/cdd 11248

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,28 +208,14 @@ uhd terraform apply:layer 20-app foo
 
 Until we finalize our strategy for ECR, you'll need to pull the latest container images and push them to your ECR:
 
-First login to ECR in the **tools** account:
-
 ```
-uhd docker ecr:login
-```
-
-Then to pull the latest images:
-
-```
-uhd docker pull
-```
-
-And to push them to your ECR:
-
-```
-uhd docker push <account> <env>
+uhd docker update <account> <env>
 ```
 
 For example:
 
 ```
-uhd docker push dev 12345678
+uhd docker update dev 12345678
 ```
 
 Note that when pushing to the ECR in the next account, you will be logged into the ECR for that account
@@ -311,11 +297,12 @@ The update command will perform the following tasks:
 2. Run `terraform init`
 3. Run `terraform apply`
 4. Run `Docker ECR login`
-5. Run `Docker pull` to grab the latest images
+5. Run `Docker pull` to grab the latest images from the tools account
 6. Run `Docker push` to deploy the latest images to your environment
 7. Switch to the dev account
 8. Restart ecs services
-9. Switch back to tools account
+9. Restart lambda functions
+10. Switch back to tools account
 
 ## Flushing caches
 

--- a/scripts/_docker.sh
+++ b/scripts/_docker.sh
@@ -58,7 +58,7 @@ function _docker_build_with_custom_tag() {
       docker buildx build -f Dockerfile-ingestion --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-ingestion-lambda:custom-${commit_hash} --push .
     fi
 
-    if [[ ${repo} == "api" ]]; then
+    if [[ ${repo} == "api" || ${repo} == "back-end" || ${repo} == "backend" ]]; then
       cd $root/../data-dashboard-api
       echo "building docker image for back end"
       local commit_hash=$(git rev-parse --short HEAD)

--- a/scripts/_docker.sh
+++ b/scripts/_docker.sh
@@ -29,7 +29,7 @@ function _docker() {
     local args=(${@:2})
 
     case $verb in
-        "build") _docker_build $args ;;
+        "build") _docker_build_with_custom_tag $args ;;
         "update") _docker_update $args ;;
         "pull") _docker_pull $args ;;
         "push") _docker_push $args ;;
@@ -38,34 +38,6 @@ function _docker() {
 
         *) _docker_help ;;
     esac
-}
-
-function _docker_build() {
-    local repo=$1
-
-    if [[ -z ${repo} ]]; then
-        echo "Repo is required" >&2
-        return 1
-    fi
-
-    local dev_account_id=$(_get_target_aws_account_id "dev")
-    local env=$(_get_env_name)
-
-    cd $root/../data-dashboard-$repo
-
-    local ecr_repo_name=$repo
-    [[ "$repo" == "frontend" ]] && ecr_repo_name=("front-end")
-
-    echo "Building docker image for $repo"
-
-    docker buildx build --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-${ecr_repo_name}:latest-graviton --push .
-    
-    if [[ "$repo" == "api" ]]; then
-        echo "building docker image for ingestion lambda"
-        docker buildx build -f Dockerfile-ingestion --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-ingestion:latest --push .
-    fi
-
-    cd $root
 }
 
 function _docker_build_with_custom_tag() {
@@ -79,19 +51,25 @@ function _docker_build_with_custom_tag() {
     local dev_account_id=$(_get_target_aws_account_id "dev")
     local env=$(_get_env_name)
 
-    cd $root/../data-dashboard-$repo
+    if [[ ${repo} == "ingestion" ]]; then
+      cd $root/../data-dashboard-api
+      echo "building docker image for ingestion lambda"
+      local commit_hash=$(git rev-parse --short HEAD)
+      docker buildx build -f Dockerfile-ingestion --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-ingestion-lambda:custom-${commit_hash} --push .
+    fi
 
-    local ecr_repo_name=$repo
-    [[ "$repo" == "frontend" ]] && ecr_repo_name=("front-end")
+    if [[ ${repo} == "api" ]]; then
+      cd $root/../data-dashboard-api
+      echo "building docker image for back end"
+      local commit_hash=$(git rev-parse --short HEAD)
+      docker buildx build --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-back-end-ecs:custom-${commit_hash} --push .
+    fi
 
-    echo "Building docker image for $repo"
-
-    local commit_hash=$(git rev-parse --short HEAD)
-    docker buildx build --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-${ecr_repo_name}:custom-${commit_hash} --push .
-
-    if [[ "$repo" == "api" ]]; then
-        echo "building docker image for ingestion lambda"
-        docker buildx build -f Dockerfile-ingestion --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-ingestion:custom-${commit_hash} --push .
+    if [[ ${repo} == "front-end" || ${repo} == "frontend" ]]; then
+      cd $root/../data-dashboard-frontend
+      echo "building docker image for front end"
+      local commit_hash=$(git rev-parse --short HEAD)
+      docker buildx build --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-front-end-ecs:custom-${commit_hash} --push .
     fi
 
     cd $root


### PR DESCRIPTION
uhd docker build api
uhd docker build backend
uhd docker build back-end

uhd docker build frontend
uhd docker build front-end

uhd docker ingestion

^ are all now valid. Also building the backend image doesn’t also build the ingestion image, that’s now done seperately.