### PR TITLE
Task/encrypt secrets with kms key/cdd 1457

### DIFF
--- a/terraform/10-account/kms.tf
+++ b/terraform/10-account/kms.tf
@@ -1,0 +1,14 @@
+module "kms_secrets" {
+	source  = "terraform-aws-modules/kms/aws"
+	version = "3.1.0"
+
+	description             = "Account level secrets encryption key"
+	key_usage               = "ENCRYPT_DECRYPT"
+	deletion_window_in_days = 7
+    multi_region            = false
+
+	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
+
+    aliases                 = ["${local.project}}-${local.account}-account-secrets"]
+	aliases_use_name_prefix = true
+}

--- a/terraform/10-account/kms.tf
+++ b/terraform/10-account/kms.tf
@@ -1,14 +1,14 @@
 module "kms_secrets" {
-	source  = "terraform-aws-modules/kms/aws"
-	version = "3.1.0"
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
 
-	description             = "Account level secrets encryption key"
-	key_usage               = "ENCRYPT_DECRYPT"
-	deletion_window_in_days = 7
-    multi_region            = false
+  description             = "Account level secrets encryption key"
+  key_usage               = "ENCRYPT_DECRYPT"
+  deletion_window_in_days = 7
+  multi_region            = false
 
-	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
+  key_owners = ["arn:aws:iam::${var.tools_account_id}:root"]
 
-    aliases                 = ["${local.project}}-${local.account}-account-secrets"]
-	aliases_use_name_prefix = true
+  aliases                 = ["${local.project}-${local.account}-account-secrets"]
+  aliases_use_name_prefix = true
 }

--- a/terraform/20-app/kms.tf
+++ b/terraform/20-app/kms.tf
@@ -12,3 +12,35 @@ module "kms_app_rds" {
     aliases                 = ["${local.prefix}-app-rds"]
 	aliases_use_name_prefix = true
 }
+
+
+module "kms_secrets_app_operator" {
+	source  = "terraform-aws-modules/kms/aws"
+	version = "3.1.0"
+
+	description             = "Encryption key secrets needed by application operator"
+	key_usage               = "ENCRYPT_DECRYPT"
+	deletion_window_in_days = 7
+    multi_region            = false
+
+	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
+
+    aliases                 = ["${local.prefix}-secrets-app-operator"]
+	aliases_use_name_prefix = true
+}
+
+
+module "kms_secrets_engineer" {
+	source  = "terraform-aws-modules/kms/aws"
+	version = "3.1.0"
+
+	description             = "Encryption key secrets needed by application engineers"
+	key_usage               = "ENCRYPT_DECRYPT"
+	deletion_window_in_days = 7
+    multi_region            = false
+
+	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
+
+    aliases                 = ["${local.prefix}-secrets-app-engineer"]
+	aliases_use_name_prefix = true
+}

--- a/terraform/20-app/kms.tf
+++ b/terraform/20-app/kms.tf
@@ -13,7 +13,7 @@ module "kms_app_rds" {
   aliases_use_name_prefix = true
 }
 
-module "kms_secrets_engineer" {
+module "kms_secrets_app_engineer" {
   source  = "terraform-aws-modules/kms/aws"
   version = "3.1.0"
 

--- a/terraform/20-app/kms.tf
+++ b/terraform/20-app/kms.tf
@@ -44,3 +44,35 @@ module "kms_secrets_engineer" {
     aliases                 = ["${local.prefix}-secrets-app-engineer"]
 	aliases_use_name_prefix = true
 }
+
+
+module "kms_secrets_app_operator" {
+	source  = "terraform-aws-modules/kms/aws"
+	version = "3.1.0"
+
+	description             = "Encryption key secrets needed by application operator"
+	key_usage               = "ENCRYPT_DECRYPT"
+	deletion_window_in_days = 7
+    multi_region            = false
+
+	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
+
+    aliases                 = ["${local.prefix}-secrets-app-operator"]
+	aliases_use_name_prefix = true
+}
+
+
+module "kms_secrets_engineer" {
+	source  = "terraform-aws-modules/kms/aws"
+	version = "3.1.0"
+
+	description             = "Encryption key secrets needed by application engineers"
+	key_usage               = "ENCRYPT_DECRYPT"
+	deletion_window_in_days = 7
+    multi_region            = false
+
+	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
+
+    aliases                 = ["${local.prefix}-secrets-app-engineer"]
+	aliases_use_name_prefix = true
+}

--- a/terraform/20-app/kms.tf
+++ b/terraform/20-app/kms.tf
@@ -1,78 +1,44 @@
 module "kms_app_rds" {
-	source  = "terraform-aws-modules/kms/aws"
-	version = "3.1.0"
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
 
-	description             = "RDS encryption key"
-	key_usage               = "ENCRYPT_DECRYPT"
-	deletion_window_in_days = 7
-    multi_region            = false
+  description             = "RDS encryption key"
+  key_usage               = "ENCRYPT_DECRYPT"
+  deletion_window_in_days = 7
+  multi_region            = false
 
-	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
+  key_owners = ["arn:aws:iam::${var.tools_account_id}:root"]
 
-    aliases                 = ["${local.prefix}-app-rds"]
-	aliases_use_name_prefix = true
+  aliases                 = ["${local.prefix}-app-rds"]
+  aliases_use_name_prefix = true
 }
-
-
-module "kms_secrets_app_operator" {
-	source  = "terraform-aws-modules/kms/aws"
-	version = "3.1.0"
-
-	description             = "Encryption key secrets needed by application operator"
-	key_usage               = "ENCRYPT_DECRYPT"
-	deletion_window_in_days = 7
-    multi_region            = false
-
-	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
-
-    aliases                 = ["${local.prefix}-secrets-app-operator"]
-	aliases_use_name_prefix = true
-}
-
 
 module "kms_secrets_engineer" {
-	source  = "terraform-aws-modules/kms/aws"
-	version = "3.1.0"
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
 
-	description             = "Encryption key secrets needed by application engineers"
-	key_usage               = "ENCRYPT_DECRYPT"
-	deletion_window_in_days = 7
-    multi_region            = false
+  description             = "Encryption key secrets needed by application engineers"
+  key_usage               = "ENCRYPT_DECRYPT"
+  deletion_window_in_days = 7
+  multi_region            = false
 
-	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
+  key_owners = ["arn:aws:iam::${var.tools_account_id}:root"]
 
-    aliases                 = ["${local.prefix}-secrets-app-engineer"]
-	aliases_use_name_prefix = true
+  aliases                 = ["${local.prefix}-secrets-app-engineer"]
+  aliases_use_name_prefix = true
 }
-
 
 module "kms_secrets_app_operator" {
-	source  = "terraform-aws-modules/kms/aws"
-	version = "3.1.0"
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
 
-	description             = "Encryption key secrets needed by application operator"
-	key_usage               = "ENCRYPT_DECRYPT"
-	deletion_window_in_days = 7
-    multi_region            = false
+  description             = "Encryption key secrets needed by application operator"
+  key_usage               = "ENCRYPT_DECRYPT"
+  deletion_window_in_days = 7
+  multi_region            = false
 
-	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
+  key_owners = ["arn:aws:iam::${var.tools_account_id}:root"]
 
-    aliases                 = ["${local.prefix}-secrets-app-operator"]
-	aliases_use_name_prefix = true
-}
-
-
-module "kms_secrets_engineer" {
-	source  = "terraform-aws-modules/kms/aws"
-	version = "3.1.0"
-
-	description             = "Encryption key secrets needed by application engineers"
-	key_usage               = "ENCRYPT_DECRYPT"
-	deletion_window_in_days = 7
-    multi_region            = false
-
-	key_owners          	= ["arn:aws:iam::${var.tools_account_id}:root"]
-
-    aliases                 = ["${local.prefix}-secrets-app-engineer"]
-	aliases_use_name_prefix = true
+  aliases                 = ["${local.prefix}-secrets-app-operator"]
+  aliases_use_name_prefix = true
 }


### PR DESCRIPTION
This PR adds the following KMS keys:
- 1 at the account layer, to encrypt secrets there
- 2 at the app layer, to encrypt secrets there. There are 2 so we can differentiate between secrets needed by the dev team and secrets needed by operators


I'll follow this up by stitching these into the relevant secrets in a follow up PR