### PR TITLE
Remove broad `PassRole` permission from operations IAM role

### DIFF
--- a/terraform/10-account/iam.operations-role.tf
+++ b/terraform/10-account/iam.operations-role.tf
@@ -54,7 +54,6 @@ module "iam_operations_policy" {
             "ecs:DescribeTasks",
             "ecs:ExecuteCommand",
             "ecs:RunTask",
-            "iam:PassRole",
             "logs:StartLiveTail",
             "logs:StopLiveTail"
           ],


### PR DESCRIPTION
Fixes CDD-2383

This will prevent operations role from SSH'ing into containers but I think that's fine, we don't really need\want that anyway