### PR TITLE
Add `auth-dev` env to CD pipeline

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - name: Configure AWS credentials for dev account
       uses: aws-actions/configure-aws-credentials@v4
-      if: ${{ inputs.account-name == 'dev' || inputs.account-name == 'dpd' }}
+      if: ${{ contains(fromJSON('["dev", "dpd", "auth-dev"]'), inputs.account-name) }}
       with:
         role-to-assume: ${{ inputs.dev-account-role }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -150,6 +150,7 @@ jobs:
       contents: write
     outputs:
       deploy_dev: ${{ steps.fast_forward_merge.outputs.deploy_dev }}
+      deploy_auth_dev: ${{ steps.fast_forward_merge.outputs.deploy_auth_dev }}
       deploy_dpd: ${{ steps.fast_forward_merge.outputs.deploy_dpd }}
       deploy_test: ${{ steps.fast_forward_merge.outputs.deploy_test }}
       deploy_staging: ${{ steps.fast_forward_merge.outputs.deploy_staging }}
@@ -176,6 +177,14 @@ jobs:
     uses: ./.github/workflows/well-known-environment.yml
     with:
       branch: env/dev/dev
+    secrets: inherit
+
+  deploy_auth_dev:
+    needs: fast_forward_env_branches
+    if: ${{needs.fast_forward_env_branches.outputs.deploy_auth_dev}}
+    uses: ./.github/workflows/well-known-environment.yml
+    with:
+      branch: env/dev/auth-dev
     secrets: inherit
 
   deploy_dpd:

--- a/scripts/fast-forward-env-branches.sh
+++ b/scripts/fast-forward-env-branches.sh
@@ -5,6 +5,7 @@ env_branches=("env/uat/uat"
               "env/test/test"
               "env/test/perf"
               "env/dev/dpd"
+              "env/dev/auth-dev"
               "env/dev/dev")
 
 for branch in ${env_branches[@]}; do 

--- a/terraform/20-app/locals.tf
+++ b/terraform/20-app/locals.tf
@@ -11,7 +11,7 @@ locals {
 
   use_prod_sizing         = contains(["perf", "pen", "prod"], local.environment)
   add_password_protection = local.environment == "staging"
-  is_auth                 = false
+  is_auth                 = local.environment == "auth-dev"
 
   wke = {
     account = ["dev", "test", "uat", "prod"]


### PR DESCRIPTION
This PR does the following:
- Hooks up the new `auth-dev` environment in the dev account to the CD pipeline.
- Switches the `is_auth` var to true for the `auth-dev` env, meaning we'll leverage Next.js built-in caching for that env and bypass the CDN

To follow up with this, we'll need to reconfigure the caching in front of the private API