### PR TITLE
Add `auth` env in dev account to CD pipeline

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - name: Configure AWS credentials for dev account
       uses: aws-actions/configure-aws-credentials@v4
-      if: ${{ contains(fromJSON('["dev", "dpd", "auth-dev"]'), inputs.account-name) }}
+      if: ${{ contains(fromJSON('["dev", "dpd", "auth"]'), inputs.account-name) }}
       with:
         role-to-assume: ${{ inputs.dev-account-role }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -150,7 +150,7 @@ jobs:
       contents: write
     outputs:
       deploy_dev: ${{ steps.fast_forward_merge.outputs.deploy_dev }}
-      deploy_auth_dev: ${{ steps.fast_forward_merge.outputs.deploy_auth_dev }}
+      deploy_auth: ${{ steps.fast_forward_merge.outputs.deploy_auth }}
       deploy_dpd: ${{ steps.fast_forward_merge.outputs.deploy_dpd }}
       deploy_test: ${{ steps.fast_forward_merge.outputs.deploy_test }}
       deploy_staging: ${{ steps.fast_forward_merge.outputs.deploy_staging }}
@@ -179,12 +179,12 @@ jobs:
       branch: env/dev/dev
     secrets: inherit
 
-  deploy_auth_dev:
+  deploy_auth:
     needs: fast_forward_env_branches
-    if: ${{needs.fast_forward_env_branches.outputs.deploy_auth_dev}}
+    if: ${{needs.fast_forward_env_branches.outputs.deploy_auth}}
     uses: ./.github/workflows/well-known-environment.yml
     with:
-      branch: env/dev/auth-dev
+      branch: env/dev/auth
     secrets: inherit
 
   deploy_dpd:

--- a/scripts/fast-forward-env-branches.sh
+++ b/scripts/fast-forward-env-branches.sh
@@ -5,7 +5,7 @@ env_branches=("env/uat/uat"
               "env/test/test"
               "env/test/perf"
               "env/dev/dpd"
-              "env/dev/auth-dev"
+              "env/dev/auth"
               "env/dev/dev")
 
 for branch in ${env_branches[@]}; do 

--- a/terraform/20-app/locals.tf
+++ b/terraform/20-app/locals.tf
@@ -11,7 +11,7 @@ locals {
 
   use_prod_sizing         = contains(["perf", "pen", "prod"], local.environment)
   add_password_protection = local.environment == "staging"
-  is_auth                 = local.environment == "auth-dev"
+  is_auth                 = local.environment == "auth"
 
   wke = {
     account = ["dev", "test", "uat", "prod"]


### PR DESCRIPTION
Redeploying to `auth` instead of `auth-dev` as our CLI tooling for well known envs didn't like the `-` character. 