### PR TITLE
Task/take name input as env name/cdd 2448

### DIFF
--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       name:
-        description: "The name of the user on your machine e.g. janedoe"
+        description: "The name of the dev environment you wish to deploy to e.g. abcd1234"
         required: true
         type: string
 
@@ -33,16 +33,11 @@ jobs:
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh
 
-      - name: Make environment name
-        uses: ./.github/actions/make-workspace-name
-        with:
-          name: ${{ github.inputs.name }}
-
       - name: Terraform apply
         run: |
           source uhd.sh
           uhd terraform init:layer 20-app
-          uhd terraform apply:layer 20-app $ENVIRONMENT_NAME
+          uhd terraform apply:layer 20-app ${{ inputs.name }}
         shell: zsh {0}
 
   push_docker_images:
@@ -60,15 +55,10 @@ jobs:
 
       - uses: ./.github/actions/setup-zsh
 
-      - name: Make environment name
-        uses: ./.github/actions/make-workspace-name
-        with:
-          name: ${{ github.inputs.name }}
-
       - name: Pull / push docker images
         run: |
           source uhd.sh
-          uhd docker update dev $ENVIRONMENT_NAME
+          uhd docker update dev ${{ inputs.name }}
         shell: zsh {0}
 
   restart_services:
@@ -87,16 +77,11 @@ jobs:
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh
 
-      - name: Make environment name
-        uses: ./.github/actions/make-workspace-name
-        with:
-          name: ${{ github.inputs.name }}
-
       - name: Terraform output
         run: |
           source uhd.sh
           uhd terraform init:layer 20-app
-          uhd terraform output:layer 20-app $ENVIRONMENT_NAME
+          uhd terraform output:layer 20-app ${{ inputs.name }}
         shell: zsh {0}
 
       - name: Configure AWS credentials for dev account
@@ -133,16 +118,11 @@ jobs:
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh
 
-      - name: Make environment name
-        uses: ./.github/actions/make-workspace-name
-        with:
-          name: ${{ github.inputs.name }}
-
       - name: Terraform output
         run: |
           source uhd.sh
           uhd terraform init:layer 20-app
-          uhd terraform output:layer 20-app $ENVIRONMENT_NAME
+          uhd terraform output:layer 20-app ${{ inputs.name }}
         shell: zsh {0}
 
       - name: Configure AWS credentials for dev account

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           source uhd.sh
           uhd terraform init:layer 20-app
-          uhd terraform output:layer 20-app ${{ inputs.name }}
+          uhd terraform output ${{ inputs.name }}
         shell: zsh {0}
 
       - name: Configure AWS credentials for dev account

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -103,7 +103,7 @@ jobs:
         shell: zsh {0}
 
   bootstrap_database:
-    name: Restart services
+    name: Bootstrap database
     runs-on: ubuntu-latest
     needs: [ "restart_services" ]
     steps:

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Make environment name
         uses: ./.github/actions/make-workspace-name
         with:
-          name: ${{ github.event.inputs.name }}
+          name: ${{ github.inputs.name }}
 
       - name: Terraform apply
         run: |
@@ -63,7 +63,7 @@ jobs:
       - name: Make environment name
         uses: ./.github/actions/make-workspace-name
         with:
-          name: ${{ github.event.inputs.name }}
+          name: ${{ github.inputs.name }}
 
       - name: Pull / push docker images
         run: |
@@ -90,7 +90,7 @@ jobs:
       - name: Make environment name
         uses: ./.github/actions/make-workspace-name
         with:
-          name: ${{ github.event.inputs.name }}
+          name: ${{ github.inputs.name }}
 
       - name: Terraform output
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Make environment name
         uses: ./.github/actions/make-workspace-name
         with:
-          name: ${{ github.event.inputs.name }}
+          name: ${{ github.inputs.name }}
 
       - name: Terraform output
         run: |

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Configure AWS credentials for dev account
         uses: ./.github/actions/configure-aws-credentials
         with:
+          account-name: "dev"
           aws-region: ${{ env.AWS_REGION }}
           dev-account-role: ${{ secrets.UHD_TERRAFORM_ROLE_DEV }}
 

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -129,6 +129,7 @@ jobs:
       - name: Configure AWS credentials for dev account
         uses: ./.github/actions/configure-aws-credentials
         with:
+          account-name: "dev"
           aws-region: ${{ env.AWS_REGION }}
           dev-account-role: ${{ secrets.UHD_TERRAFORM_ROLE_DEV }}
 

--- a/scripts/_terraform.sh
+++ b/scripts/_terraform.sh
@@ -508,25 +508,35 @@ function _get_etl_sibling_aws_account_id() {
 
 function _get_target_aws_account_name() {
     local layer=$1
-    local workspace=$2 
+    local workspace=$2
 
     if [[ $layer == "10-account" ]]; then
         echo $workspace
     else
-        if [[ $workspace == "prod" ]]; then
-            echo "prod"
-        elif [[ $CI == "true" ]]; then
-            if [[ $branch == "env/dev/"* ]]; then
-                echo "dev"
-            elif [[ $branch == "env/uat/"* ]]; then
-                echo "uat"
-            else
-                echo "test"
-            fi    
-        else
-            echo "dev"
-        fi
-    fi 
+      # This is an app-layer change
+      if [[ $workspace == "prod" ]]; then
+          echo "prod"
+
+      elif [[ $CI == "true" ]]; then
+          if [[ $workspace == ci-* ]]; then
+              echo "test"
+          else
+              case $branch in
+                  env/dev/*)   echo "dev" ;;
+                  env/uat/*)   echo "uat" ;;
+                  env/test/*)  echo "test" ;;
+                  *)           echo "dev" ;;
+                  # In this case, the CI is actively looking
+                  # to deploy to the dev account not the test account
+              esac
+          fi
+
+      else
+          # If we don't want prod, and we're not in the CI environment
+          # then we're interested in deploying to the dev account
+          echo "dev"
+      fi
+    fi
 }
 
 


### PR DESCRIPTION
This PR updates the personal dev environments workflow so that:

- It takes the name input as the env to be deployed to directly and doesn't try to compute the hash. This means the engineer has to get their env ID ahead of time (I'll set up a seperate workflow for this)
- Updates the CLI tooling so that the CI environment can target the dev account in cases like this

To follow up, I'm going to:
- Set the bootstrap job build to wait for that ECS task to finish, cause right now it is just fire and forget
- When the bootstrap job is finished, flush the caches for that env
- To make things easier for engineers & QA, I'll set up a new workflow to allow us to flush caches for any personal dev environment (this will be seperate to the current one for well known environments) 