### PR TITLE
Task/flush caches after bootstrap job/cdd 2448

### DIFF
--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -142,6 +142,7 @@ jobs:
   flush_caches:
     name: Flush caches
     runs-on: ubuntu-latest
+    needs: ["bootstrap_database"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-terraform

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           source uhd.sh
           uhd terraform init:layer 20-app
-          uhd terraform output ${{ inputs.environment }}
+          uhd terraform output ${{ inputs.name }}
         shell: zsh {0}
 
       - name: Configure AWS credentials for account

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -138,3 +138,43 @@ jobs:
           source uhd.sh
           uhd ecs run-and-wait bootstrap-env
         shell: zsh {0}
+
+  flush_caches:
+    name: Flush caches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-terraform
+      - uses: ./.github/actions/setup-zsh
+
+      - name: Configure AWS credentials for tools account
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          tools-account-role: ${{ secrets.UHD_TERRAFORM_IAM_ROLE }}
+
+      - name: Terraform output
+        run: |
+          source uhd.sh
+          uhd terraform init:layer 20-app
+          uhd terraform output ${{ inputs.environment }}
+        shell: zsh {0}
+
+      - name: Configure AWS credentials for account
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          account-name: "dev"
+          aws-region: ${{ env.AWS_REGION }}
+          dev-account-role: ${{ secrets.UHD_TERRAFORM_ROLE_DEV }}
+
+      - name: Flush caches
+        run: |
+          source uhd.sh
+          uhd cache flush
+        shell: zsh {0}
+
+      - name: Restart front end
+        run: |
+          source uhd.sh
+          uhd ecs restart-containers front_end
+        shell: zsh {0}

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -136,5 +136,5 @@ jobs:
       - name: Bootstrap app database with truncated test dataset
         run: |
           source uhd.sh
-          uhd ecs run bootstrap-env
+          uhd ecs run-and-wait bootstrap-env
         shell: zsh {0}

--- a/scripts/_ecs.sh
+++ b/scripts/_ecs.sh
@@ -10,7 +10,8 @@ function _ecs_help() {
     echo "  restart-services                   - restarts all the ecs services after deploying the most recent images"
     echo "  restart-containers <service_name>  - restarts the containers for a given ECS service with the same image"
     echo
-    echo "  run <job name>                     - run the specified job"
+    echo "  run <job name>                     - run the specified job in a fire and forget fashion"
+    echo "  run-and-wait <job name>            - run the specified job and wait for it to complete"
     echo "  logs <env> <task id>               - tail logs for the specified task"
     echo "  ssh <task id> <container name>     - ssh into a container"
     echo
@@ -24,6 +25,7 @@ function _ecs() {
 
     case $verb in
         "run") _ecs_run $args ;;
+        "run-and-wait") _ecs_run_and_wait $args ;;
         "restart-services") _ecs_restart_services $args ;;
         "restart-containers") _ecs_restart_containers $args ;;
         "help") _ecs_help ;;
@@ -45,6 +47,31 @@ function _ecs_run() {
     echo Starting job....
 
     aws ecs run-task --cli-input-json "file://terraform/20-app/ecs-jobs/${job}.json" | jq ".tasks[0].taskArn"
+}
+
+function _ecs_run_and_wait() {
+    local job=$1
+
+    if [[ -z ${job} ]]; then
+        echo "Job is required" >&2
+        return 1
+    fi
+
+    echo Starting job....
+
+    current_cluster_name=$(_get_current_cluster)
+
+    task_arn=$(aws ecs run-task --cli-input-json "file://terraform/20-app/ecs-jobs/${job}.json" | jq -r ".tasks[0].taskArn")
+    echo "Job (${task_arn}) is now running, waiting for completion..."
+
+    aws ecs wait tasks-stopped --tasks ${task_arn} --cluster ${current_cluster_name}
+
+    echo "Job (${task_arn}) completed successfully"
+}
+
+function _get_current_cluster() {
+  local terraform_output_file=terraform/20-app/output.json
+  jq -r '.ecs.value.cluster_name' ${terraform_output_file}
 }
 
 function _ecs_logs() {


### PR DESCRIPTION
This PR does the following:

- Waits for the bootstrap db job to send an exit signal before closing the CI build
- Flushes the caches for that env straight after the bootstrap job has completed

The next step will be to add a conditional to allow the `bootstrap_database` build to be skipped 