### PR TITLE
Task/add workflow to deploy feature branches/cdd 2448

### DIFF
--- a/.github/workflows/create-personal-dev-environment.yml
+++ b/.github/workflows/create-personal-dev-environment.yml
@@ -1,0 +1,181 @@
+name: Create Personal Development Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "The name of the dev environment you wish to deploy to e.g. abcd1234"
+        required: true
+        type: string
+
+env:
+  AWS_REGION: "eu-west-2"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform_apply:
+    name: Terraform apply
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+
+      - name: Configure AWS credentials for tools account
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          tools-account-role: ${{ secrets.UHD_TERRAFORM_IAM_ROLE }}
+          role-duration-seconds: "7200"
+
+      - uses: ./.github/actions/setup-terraform
+      - uses: ./.github/actions/setup-zsh
+
+      - name: Terraform apply
+        run: |
+          source uhd.sh
+          uhd terraform init:layer 20-app
+          uhd terraform apply:layer 20-app ${{ inputs.name }}
+        shell: zsh {0}
+
+  push_docker_images:
+    name: Push docker images
+    runs-on: ubuntu-latest
+    needs: ["terraform_apply"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials for tools account
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          tools-account-role: ${{ secrets.UHD_TERRAFORM_IAM_ROLE }}
+
+      - uses: ./.github/actions/setup-zsh
+
+      - name: Pull / push docker images
+        run: |
+          source uhd.sh
+          uhd docker update dev ${{ inputs.name }}
+        shell: zsh {0}
+
+  restart_services:
+    name: Restart services
+    runs-on: ubuntu-latest
+    needs: ["push_docker_images"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials for tools account
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          tools-account-role: ${{ secrets.UHD_TERRAFORM_IAM_ROLE }}
+
+      - uses: ./.github/actions/setup-terraform
+      - uses: ./.github/actions/setup-zsh
+
+      - name: Terraform output
+        run: |
+          source uhd.sh
+          uhd terraform init:layer 20-app
+          uhd terraform output:layer 20-app ${{ inputs.name }}
+        shell: zsh {0}
+
+      - name: Configure AWS credentials for dev account
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          account-name: "dev"
+          aws-region: ${{ env.AWS_REGION }}
+          dev-account-role: ${{ secrets.UHD_TERRAFORM_ROLE_DEV }}
+
+      - name: Restart ECS services
+        run: |
+          source uhd.sh
+          uhd ecs restart-services
+        shell: zsh {0}
+
+      - name: Redeploy lambda functions
+        run: |
+          source uhd.sh
+          uhd lambda restart-functions
+        shell: zsh {0}
+
+  bootstrap_database:
+    name: Bootstrap database
+    runs-on: ubuntu-latest
+    needs: [ "restart_services" ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials for tools account
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          tools-account-role: ${{ secrets.UHD_TERRAFORM_IAM_ROLE }}
+
+      - uses: ./.github/actions/setup-terraform
+      - uses: ./.github/actions/setup-zsh
+
+      - name: Terraform output
+        run: |
+          source uhd.sh
+          uhd terraform init:layer 20-app
+          uhd terraform output ${{ inputs.name }}
+        shell: zsh {0}
+
+      - name: Configure AWS credentials for dev account
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          account-name: "dev"
+          aws-region: ${{ env.AWS_REGION }}
+          dev-account-role: ${{ secrets.UHD_TERRAFORM_ROLE_DEV }}
+
+      - name: Bootstrap app database with truncated test dataset
+        run: |
+          source uhd.sh
+          uhd ecs run-and-wait bootstrap-env
+        shell: zsh {0}
+
+  flush_caches:
+    name: Flush caches
+    runs-on: ubuntu-latest
+    needs: ["bootstrap_database"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-terraform
+      - uses: ./.github/actions/setup-zsh
+
+      - name: Configure AWS credentials for tools account
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          tools-account-role: ${{ secrets.UHD_TERRAFORM_IAM_ROLE }}
+
+      - name: Terraform output
+        run: |
+          source uhd.sh
+          uhd terraform init:layer 20-app
+          uhd terraform output ${{ inputs.name }}
+        shell: zsh {0}
+
+      - name: Configure AWS credentials for account
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          account-name: "dev"
+          aws-region: ${{ env.AWS_REGION }}
+          dev-account-role: ${{ secrets.UHD_TERRAFORM_ROLE_DEV }}
+
+      - name: Flush caches
+        run: |
+          source uhd.sh
+          uhd cache flush
+        shell: zsh {0}
+
+      - name: Restart front end
+        run: |
+          source uhd.sh
+          uhd ecs restart-containers front_end
+        shell: zsh {0}

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -1,4 +1,4 @@
-name: Deploy Personal Dev Environment
+name: Deploy Personal Development Environment
 
 on:
   workflow_dispatch:
@@ -6,6 +6,14 @@ on:
       name:
         description: "The name of the dev environment you wish to deploy to e.g. abcd1234"
         required: true
+        type: string
+      frontend_branch:
+        description: "The name of the git branch from the frontend which should be deployed"
+        default: "main"
+        type: string
+      backend_branch:
+        description: "The name of the git branch from the backend which should be deployed"
+        default: "main"
         type: string
 
 env:
@@ -55,10 +63,24 @@ jobs:
 
       - uses: ./.github/actions/setup-zsh
 
-      - name: Pull / push docker images
+      - name: Checkout all repos
         run: |
           source uhd.sh
-          uhd docker update dev ${{ inputs.name }}
+          uhd gh clone
+        shell: zsh {0}
+
+      - name: Build frontend image
+        run: |
+          source uhd.sh
+          uhd gh co frontend {{ inputs.frontend_branch }}
+          uhd docker build frontend
+        shell: zsh {0}
+
+      - name: Build backend image
+        run: |
+          source uhd.sh
+          uhd gh co api {{ inputs.backend_branch }}
+          uhd docker build backend
         shell: zsh {0}
 
   restart_services:
@@ -103,46 +125,10 @@ jobs:
           uhd lambda restart-functions
         shell: zsh {0}
 
-  bootstrap_database:
-    name: Bootstrap database
-    runs-on: ubuntu-latest
-    needs: [ "restart_services" ]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure AWS credentials for tools account
-        uses: ./.github/actions/configure-aws-credentials
-        with:
-          aws-region: ${{ env.AWS_REGION }}
-          tools-account-role: ${{ secrets.UHD_TERRAFORM_IAM_ROLE }}
-
-      - uses: ./.github/actions/setup-terraform
-      - uses: ./.github/actions/setup-zsh
-
-      - name: Terraform output
-        run: |
-          source uhd.sh
-          uhd terraform init:layer 20-app
-          uhd terraform output ${{ inputs.name }}
-        shell: zsh {0}
-
-      - name: Configure AWS credentials for dev account
-        uses: ./.github/actions/configure-aws-credentials
-        with:
-          account-name: "dev"
-          aws-region: ${{ env.AWS_REGION }}
-          dev-account-role: ${{ secrets.UHD_TERRAFORM_ROLE_DEV }}
-
-      - name: Bootstrap app database with truncated test dataset
-        run: |
-          source uhd.sh
-          uhd ecs run-and-wait bootstrap-env
-        shell: zsh {0}
-
   flush_caches:
     name: Flush caches
     runs-on: ubuntu-latest
-    needs: ["bootstrap_database"]
+    needs: ["restart_services"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-terraform

--- a/scripts/_gh.sh
+++ b/scripts/_gh.sh
@@ -58,7 +58,7 @@ function _gh_co() {
    local repo=$1
    local target=$2
 
-   if [[ $1 =~ ^[0-9]+$ ]]; then
+   if [[ $target =~ ^[0-9]+$ ]]; then
      _gh_checkout_pr $repo $target
    fi
 

--- a/scripts/_gh.sh
+++ b/scripts/_gh.sh
@@ -5,11 +5,11 @@ function _gh_help() {
     echo "uhd gh <command> [options]"
     echo
     echo "commands:"
-    echo "  help           - this help screen"
+    echo "  help                       - this help screen"
     echo 
-    echo "  clone          - clone all the repos"
-    echo "  co [repo] [pr] - checkout the specified pull request"
-    echo "  main           - switch to main branch in all repos and pull the latest if possible"
+    echo "  clone                      - clone all the repos"
+    echo "  co [repo] [pr | branch]    - checkout the specified pull request or git branch"
+    echo "  main                       - switch to main branch in all repos and pull the latest if possible"
     echo
 
     return 0
@@ -55,6 +55,17 @@ function _gh_main() {
 }
 
 function _gh_co() {
+   local repo=$1
+   local target=$2
+
+   if [[ $1 =~ ^[0-9]+$ ]]; then
+     _gh_checkout_pr $repo $target
+   fi
+
+   _gh_checkout_branch $repo $target
+}
+
+function _gh_checkout_pr() {
     local repo=$1
     local pr=$2
 
@@ -75,6 +86,29 @@ function _gh_co() {
 
     cd $root 
 
+}
+
+function _gh_checkout_branch() {
+    local repo=$1
+    local branch=$2
+
+    if [[ -z ${repo} ]]; then
+        echo "Repo is required" >&2
+        return 1
+    fi
+
+    if [[ -z ${branch} ]]; then
+        echo "Branch is required" >&2
+        return 1
+    fi
+
+    echo "Checking out branch $branch in data-dashboard-$repo"
+
+    cd $root/../data-dashboard-$repo
+    git checkout $branch
+    git pull
+
+    cd $root
 }
 
 function _gh_get_repos() {


### PR DESCRIPTION
This PR does the following:

- Makes a new workflow which allows us to deploy feature branches from BE & FE to a given dev environment
- Rename the 1st deploy personal env workflow to `Create Personal Dev Environment`, this also includes bootstrapping the db, so is effectively only to be used for new envs, or to 'reset' the data in that db