### PR TITLE
Apply IP allow list to CMS application regardless of environment type

### DIFF
--- a/terraform/20-app/ip-allow-lists.tf
+++ b/terraform/20-app/ip-allow-lists.tf
@@ -24,6 +24,8 @@ locals {
       "80.1.216.85/32",     # Kola Olusola
       "86.164.230.184/32",  # Joe Gasewicz
       "86.130.56.204/32",   # Chris Warren
+      "147.161.236.91/32",  # Jeff Thomas - Windows
+      "81.106.144.243/32",  # Jeff Thomas - Macbook
       "146.198.70.45/32",   # Mike Elshaw
     ],
     project_team = [

--- a/terraform/20-app/ip-allow-lists.tf
+++ b/terraform/20-app/ip-allow-lists.tf
@@ -24,8 +24,6 @@ locals {
       "80.1.216.85/32",     # Kola Olusola
       "86.164.230.184/32",  # Joe Gasewicz
       "86.130.56.204/32",   # Chris Warren
-      "147.161.236.91/32",  # Jeff Thomas - Windows
-      "81.106.144.243/32",  # Jeff Thomas - Macbook
       "146.198.70.45/32",   # Mike Elshaw
     ],
     project_team = [

--- a/terraform/20-app/waf.cms.tf
+++ b/terraform/20-app/waf.cms.tf
@@ -3,6 +3,10 @@ resource "aws_wafv2_web_acl" "cms_admin" {
   description = "Web ACL for CMS application"
   scope       = "REGIONAL"
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   default_action {
     dynamic "block" {
       for_each = [""]

--- a/terraform/20-app/waf.cms.tf
+++ b/terraform/20-app/waf.cms.tf
@@ -4,39 +4,37 @@ resource "aws_wafv2_web_acl" "cms_admin" {
   scope       = "REGIONAL"
 
   default_action {
-    allow {}
-  }
-
-  dynamic "rule" {
-    for_each = local.waf_cms_admin.rules
-
-    content {
-      name     = rule.value.name
-      priority = rule.value.priority
-
-      override_action {
-        none {}
+    dynamic "block" {
+      for_each = [""]
+      content {
       }
-
-      statement {
-        managed_rule_group_statement {
-          name        = rule.value.name
-          vendor_name = "AWS"
-        }
-      }
-
-      visibility_config {
-        metric_name                = rule.value.name
-        cloudwatch_metrics_enabled = true
-        sampled_requests_enabled   = true
+    }
+    dynamic "allow" {
+      for_each = []
+      content {
       }
     }
   }
 
-  visibility_config {
-    metric_name                = "${local.prefix}-cms"
-    cloudwatch_metrics_enabled = true
-    sampled_requests_enabled   = true
+  rule {
+    name     = "ip-allowlist"
+    priority = 0
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.ip_allow_list_regional.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "IPAllowListRule"
+      sampled_requests_enabled   = true
+    }
   }
 
   rule {
@@ -86,6 +84,38 @@ resource "aws_wafv2_web_acl" "cms_admin" {
       metric_name                = "RateLimitRule"
       sampled_requests_enabled   = true
     }
+  }
+
+  dynamic "rule" {
+    for_each = local.waf_cms_admin.rules
+
+    content {
+      name     = rule.value.name
+      priority = rule.value.priority
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          name        = rule.value.name
+          vendor_name = "AWS"
+        }
+      }
+
+      visibility_config {
+        metric_name                = rule.value.name
+        cloudwatch_metrics_enabled = true
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  visibility_config {
+    metric_name                = "${local.prefix}-cms"
+    cloudwatch_metrics_enabled = true
+    sampled_requests_enabled   = true
   }
 }
 

--- a/terraform/20-app/waf.ip-allow-set.tf
+++ b/terraform/20-app/waf.ip-allow-set.tf
@@ -17,4 +17,6 @@ resource "aws_wafv2_ip_set" "ip_allow_list_regional" {
     local.complete_ip_allow_list,
     formatlist("%s/32", module.vpc.nat_public_ips)
   )
+
+  depends_on = [aws_wafv2_web_acl.cms_admin]
 }

--- a/terraform/20-app/waf.ip-allow-set.tf
+++ b/terraform/20-app/waf.ip-allow-set.tf
@@ -17,6 +17,4 @@ resource "aws_wafv2_ip_set" "ip_allow_list_regional" {
     local.complete_ip_allow_list,
     formatlist("%s/32", module.vpc.nat_public_ips)
   )
-
-  depends_on = [aws_wafv2_web_acl.cms_admin]
 }

--- a/terraform/20-app/waf.ip-allow-set.tf
+++ b/terraform/20-app/waf.ip-allow-set.tf
@@ -8,3 +8,13 @@ resource "aws_wafv2_ip_set" "ip_allow_list" {
         formatlist("%s/32", module.vpc.nat_public_ips)
     )
 }
+
+resource "aws_wafv2_ip_set" "ip_allow_list_regional" {
+  name               = "${local.prefix}-ip-allow-list-regional"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = concat(
+    local.complete_ip_allow_list,
+    formatlist("%s/32", module.vpc.nat_public_ips)
+  )
+}


### PR DESCRIPTION
This PR does the following:

- Enforces the IP allow list on the CMS WAF regardless of whether its dev or not