### PR TITLE
Task/auth cicd pipeline part 1/cdd 2442

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -25,8 +25,14 @@ inputs:
   dev-account-role:
     description: "The role associated with the dev account"
     required: false
+  auth-dev-account-role:
+    description: "The role associated with the auth-dev account"
+    required: false
   test-account-role:
     description: "The role associated with the test account"
+    required: false
+  auth-test-account-role:
+    description: "The role associated with the auth-test account"
     required: false
   uat-account-role:
     description: "The role associated with the uat account"
@@ -61,11 +67,29 @@ runs:
         role-chaining: true
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
+    - name: Configure AWS credentials for auth-dev account
+      uses: aws-actions/configure-aws-credentials@v4
+      if: ${{ contains(fromJSON('["auth-dev", "auth-dpd"]'), inputs.account-name) }}
+      with:
+        role-to-assume: ${{ inputs.auth-dev-account-role }}
+        aws-region: ${{ inputs.aws-region }}
+        role-chaining: true
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
+
     - name: Configure AWS credentials for test account
       uses: aws-actions/configure-aws-credentials@v4
       if: ${{ contains(fromJSON('["test", "perf"]'), inputs.account-name) }}
       with:
         role-to-assume: ${{ inputs.test-account-role }}
+        aws-region: ${{ inputs.aws-region }}
+        role-chaining: true
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
+
+    - name: Configure AWS credentials for auth-test account
+      uses: aws-actions/configure-aws-credentials@v4
+      if: ${{ contains(fromJSON('["auth-test", "auth-perf"]'), inputs.account-name) }}
+      with:
+        role-to-assume: ${{ inputs.auth-test-account-role }}
         aws-region: ${{ inputs.aws-region }}
         role-chaining: true
         role-duration-seconds: ${{ inputs.role-duration-seconds }}

--- a/terraform/10-account/etc/auth-dev.tfvars
+++ b/terraform/10-account/etc/auth-dev.tfvars
@@ -1,0 +1,3 @@
+account_dns_name        = "auth-dev.ukhsa-dashboard.data.gov.uk"
+legacy_account_dns_name = "auth-dev.coronavirus.data.gov.uk"
+halo_account_type       = "nl8"

--- a/terraform/10-account/etc/auth-test.tfvars
+++ b/terraform/10-account/etc/auth-test.tfvars
@@ -1,0 +1,3 @@
+account_dns_name        = "auth-test.ukhsa-dashboard.data.gov.uk"
+legacy_account_dns_name = "auth-test.coronavirus.data.gov.uk"
+halo_account_type       = "nl7"


### PR DESCRIPTION
This PR does the following:

- Allows for assuming of the terraform role in the auth dev and auth test accounts
- Adds the tf vars needed for the account layers for auth dev and auth test