### PR TITLE
Reduce name length of ALB target group for CMS admin app

### DIFF
--- a/terraform/20-app/alb.cms-admin.tf
+++ b/terraform/20-app/alb.cms-admin.tf
@@ -18,8 +18,8 @@ module "cms_admin_alb" {
   }
 
   target_groups = {
-    "${local.prefix}-cms-admin-tg" = {
-      name              = "${local.prefix}-cms-admin-tg"
+    "${local.prefix}-cms-admin" = {
+      name              = "${local.prefix}-cms-admin"
       backend_protocol  = "HTTP"
       backend_port      = 80
       target_type       = "ip"
@@ -47,7 +47,7 @@ module "cms_admin_alb" {
       target_group_index = 0
       ssl_policy         = local.alb_security_policy
       forward = {
-        target_group_key = "${local.prefix}-cms-admin-tg"
+        target_group_key = "${local.prefix}-cms-admin"
       }
     }
   }

--- a/terraform/20-app/ecs.service.cms-admin.tf
+++ b/terraform/20-app/ecs.service.cms-admin.tf
@@ -74,7 +74,7 @@ module "ecs_service_cms_admin" {
 
   load_balancer = {
     service = {
-      target_group_arn = module.cms_admin_alb.target_groups["${local.prefix}-cms-admin-tg"].arn
+      target_group_arn = module.cms_admin_alb.target_groups["${local.prefix}-cms-admin"].arn
       container_name   = "api"
       container_port   = 80
     }


### PR DESCRIPTION
These PRs strip off the -tg from ALB target group names. I had to add these originally when I did a version bump of the alb terraform module which reimplemented how they handle target groups and listeners. 
Terraform / AWS (I can't remember which) couldn't handle the fact that there were existing target groups with the same name, hence at the time I had to append `-tg` to the target group names everywhere.

These PRs revert that back now because we'll likely hit character limits for the auth pipeline where we need to append some kind of identifier in the name of the ephemeral workspace to distinguish it from the main ci envs