### PR TITLE
chore: Update the docker build command to turn off the provenance setting

### DIFF
--- a/scripts/_docker.sh
+++ b/scripts/_docker.sh
@@ -62,21 +62,21 @@ function _docker_build_with_custom_tag() {
       cd $root/../data-dashboard-api
       echo "building docker image for ingestion lambda"
       local commit_hash=$(git rev-parse --short HEAD)
-      docker buildx build -f Dockerfile-ingestion --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-ingestion-lambda:custom-${commit_hash}-${RANDOM} --push .
+      docker buildx build -f Dockerfile-ingestion --platform linux/arm64 --provenance=false -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-ingestion-lambda:custom-${commit_hash}-${RANDOM} --push .
     fi
 
     if [[ ${repo} == "api" || ${repo} == "back-end" || ${repo} == "backend" ]]; then
       cd $root/../data-dashboard-api
       echo "building docker image for back end"
       local commit_hash=$(git rev-parse --short HEAD)
-      docker buildx build --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-back-end-ecs:custom-${commit_hash}-${RANDOM} --push .
+      docker buildx build --platform linux/arm64 --provenance=false -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-back-end-ecs:custom-${commit_hash}-${RANDOM} --push .
     fi
 
     if [[ ${repo} == "front-end" || ${repo} == "frontend" ]]; then
       cd $root/../data-dashboard-frontend
       echo "building docker image for front end"
       local commit_hash=$(git rev-parse --short HEAD)
-      docker buildx build --platform linux/arm64 -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-front-end-ecs:custom-${commit_hash}-${RANDOM} --push .
+      docker buildx build --platform linux/arm64 --provenance=false -t ${dev_account_id}.dkr.ecr.eu-west-2.amazonaws.com/uhd-${env}-front-end-ecs:custom-${commit_hash}-${RANDOM} --push .
     fi
 
     cd $root


### PR DESCRIPTION
ECR does not handle multi-architecture container images well and as such handles them slightly differently. 

This is an example of how multi-architecture images are displayed at the moment: 
![image](https://github.com/user-attachments/assets/9b19bd57-6e9f-40a1-958f-bfe5cd3ce364)

When the provinence setting is turned off as part of the build command the image is then represented as: 
![image](https://github.com/user-attachments/assets/3b9fd9f1-a39b-4182-8bcf-154ebca4eb18)

This then works as expected with other commands within uhd. 

Reference to stack overflow article that explains far better than I have: https://stackoverflow.com/questions/77207485/why-are-there-extra-untagged-images-in-amazon-ecr-after-doing-docker-push
