### PR TITLE
Add ingest archive bucket c/w file versioning & policy to transfer inbound files to glacier storage class

### DIFF
--- a/terraform/20-app/lambda.ingestion.tf
+++ b/terraform/20-app/lambda.ingestion.tf
@@ -62,7 +62,7 @@ module "lambda_ingestion" {
     add_items_to_ingest_archive_bucket = {
       actions   = ["s3:PutObject"]
       effect    = "Allow"
-      resources = ["${module.s3_ingest_archive.s3_bucket_arn}/*"]
+      resources = ["${module.s3_ingest_archive.s3_bucket_arn}/processed/*"]
     }
     get_db_credentials_from_secrets_manager = {
       effect    = "Allow",

--- a/terraform/20-app/lambda.ingestion.tf
+++ b/terraform/20-app/lambda.ingestion.tf
@@ -33,6 +33,7 @@ module "lambda_ingestion" {
 
   environment_variables = {
     INGESTION_BUCKET_NAME              = module.s3_ingest.s3_bucket_id
+    INGESTION_ARCHIVE_BUCKET_NAME      = module.s3_ingest_archive.s3_bucket_id
     POSTGRES_DB                        = module.aurora_db_app.cluster_database_name
     POSTGRES_HOST                      = module.aurora_db_app.cluster_endpoint
     POSTGRES_USER                      = module.aurora_db_app.cluster_master_username
@@ -57,6 +58,11 @@ module "lambda_ingestion" {
       actions   = ["s3:PutObject"]
       effect    = "Allow"
       resources = ["${module.s3_ingest.s3_bucket_arn}/failed/*"]
+    }
+    add_items_to_ingest_archive_bucket = {
+      actions   = ["s3:PutObject", "s3:HeadObject"]
+      effect    = "Allow"
+      resources = ["${module.s3_ingest_archive.s3_bucket_arn}/*"]
     }
     get_db_credentials_from_secrets_manager = {
       effect    = "Allow",

--- a/terraform/20-app/lambda.ingestion.tf
+++ b/terraform/20-app/lambda.ingestion.tf
@@ -60,7 +60,7 @@ module "lambda_ingestion" {
       resources = ["${module.s3_ingest.s3_bucket_arn}/failed/*"]
     }
     add_items_to_ingest_archive_bucket = {
-      actions   = ["s3:PutObject", "s3:HeadObject"]
+      actions   = ["s3:PutObject"]
       effect    = "Allow"
       resources = ["${module.s3_ingest_archive.s3_bucket_arn}/*"]
     }

--- a/terraform/20-app/s3.ingest-archive.tf
+++ b/terraform/20-app/s3.ingest-archive.tf
@@ -1,0 +1,33 @@
+module "s3_ingest_archive" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "4.5.0"
+
+  bucket = "${local.s3_ingest_bucket_name}-archive"
+
+  attach_deny_insecure_transport_policy = true
+  force_destroy                         = true
+
+  versioning = {
+    status     = true
+    mfa_delete = false
+  }
+
+  logging = {
+    target_bucket = data.aws_s3_bucket.s3_access_logs.id
+    target_prefix = "${local.s3_ingest_bucket_name}-archive/"
+  }
+
+  lifecycle_rule = [
+    {
+      id      = "archive"
+      enabled = true
+      filter = {
+        prefix = ""
+      }
+      transition = {
+        days          = 0
+        storage_class = "GLACIER_IR"
+      }
+    },
+  ]
+}


### PR DESCRIPTION
This PR does the following:

- Adds a new s3 bucket called `ingest-archive`
- The new bucket comes with versioning. This allows us to see files which have been overwritten for a given file name
- The bucket also implements a policy which reclassifies all inbound files to the glacier storage class, although when we push the files into the bucket, we'll request the glacier storage class, this is more of a fallback type thing