### PR TITLE
Bug/pin loose caret module versions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Build base env
         run: |
           source uhd.sh
-          uhd terraform init:layer 20-app
-          uhd terraform apply:layer 20-app ci-$SHORT_SHA
+#          uhd terraform init:layer 20-app
+#          uhd terraform apply:layer 20-app ci-$SHORT_SHA
         shell: zsh {0}
 
   unit_test_functions:

--- a/terraform/10-account/sqs.sentinel-alb-access-logs.tf
+++ b/terraform/10-account/sqs.sentinel-alb-access-logs.tf
@@ -1,5 +1,6 @@
 module "sqs_sentinel_alb_access_logs" {
-  source = "terraform-aws-modules/sqs/aws"
+  source  = "terraform-aws-modules/sqs/aws"
+  version = "4.3.1"
 
   name = "uhd-sentinel-alb-access-logs"
 

--- a/terraform/20-app/.terraform.lock.hcl
+++ b/terraform/20-app/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.98.0"
-  constraints = ">= 3.29.0, >= 3.74.0, >= 4.66.1, >= 5.0.0, >= 5.12.0, >= 5.25.0, >= 5.32.0, >= 5.37.0, >= 5.46.0, >= 5.49.0, >= 5.58.0, >= 5.61.0, >= 5.70.0, >= 5.85.0, >= 5.98.0, 5.98.0"
+  constraints = ">= 3.29.0, >= 3.74.0, >= 4.66.1, >= 5.0.0, >= 5.12.0, >= 5.25.0, >= 5.32.0, >= 5.37.0, >= 5.46.0, >= 5.49.0, >= 5.58.0, >= 5.61.0, >= 5.70.0, >= 5.98.0, 5.98.0"
   hashes = [
     "h1:KgOCdSG6euSc2lquuFlISJU/CzQTRhAO7WoaASxLZRc=",
     "h1:neMFK/kP1KT6cTGID+Tkkt8L7PsN9XqwrPDGXVw3WVY=",

--- a/terraform/20-app/eventbridge.tf
+++ b/terraform/20-app/eventbridge.tf
@@ -1,4 +1,5 @@
 module "eventbridge" {
+  version    = "3.17.1"
   source     = "terraform-aws-modules/eventbridge/aws"
   create_bus = false
   role_name  = "${local.prefix}-eventbridge-role"


### PR DESCRIPTION
This morning all our workflows were breaking because some modules were now depending on the latest version of the AWS provider (v6.0.0). 

However, this version introduces a [breaking change](https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/291) with the ECS service module that we use.

The issue was that we use an SQS module in the account layer and an eventbridge module in the app layer. Both of which did not specify a version, which mean they always pulled the latest module version. But they've just had new modules published for them, which depend on v6.0.0 of the AWS provider, hence the offline introduction of the new dependency.

I've pinned those modules now so that we can continue to use `v5.98.0` as before.
Once the next ECS module gets published, we can bump to that and also move over to v6.0.0 of the AWS provider