### PR TITLE
Temporarily scale out FE and private API services

### DIFF
--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -11,8 +11,8 @@ module "ecs_service_front_end" {
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
-  desired_count            = local.use_prod_sizing ? 3 : 1
-  autoscaling_min_capacity = local.use_prod_sizing ? 3 : 1
+  desired_count            = local.use_prod_sizing ? 6 : 1
+  autoscaling_min_capacity = local.use_prod_sizing ? 6 : 1
   autoscaling_max_capacity = local.use_prod_sizing ? 20 : 1
 
   # Temporarily drop scheduled scale in actions for out of hours operation

--- a/terraform/20-app/ecs.service.private-api.tf
+++ b/terraform/20-app/ecs.service.private-api.tf
@@ -11,8 +11,8 @@ module "ecs_service_private_api" {
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
-  desired_count            = local.use_prod_sizing ? 3 : 1
-  autoscaling_min_capacity = local.use_prod_sizing ? 3 : 1
+  desired_count            = local.use_prod_sizing ? 6 : 1
+  autoscaling_min_capacity = local.use_prod_sizing ? 6 : 1
   autoscaling_max_capacity = local.use_prod_sizing ? 20 : 1
 
   # Temporarily drop scheduled scale in actions for out of hours operation


### PR DESCRIPTION
Scale out the FE and private API ECS services to a higher standing load of 6, to help mitigate the memory leak in the fetch library in the FE