### PR TITLE
Add scheduler to shut down db clusters overnight + over weekends for non-prod envs only

### DIFF
--- a/terraform/20-app/eventbridge.scheduled-scaling.tf
+++ b/terraform/20-app/eventbridge.scheduled-scaling.tf
@@ -1,0 +1,66 @@
+locals {
+  db_scale_up_cron_expression   = "cron(30 07 ? * MON-FRI *)"
+  db_scale_down_cron_expression = "cron(10 20 ? * MON-FRI *)"
+}
+
+module "eventbridge_scheduled_scaling" {
+  source  = "terraform-aws-modules/eventbridge/aws"
+  version = "3.17.1"
+  create  = local.is_scaled_down_overnight
+
+  create_bus         = false
+  create_role        = true
+  role_name          = "${local.prefix}-eventbridge-scheduled-scaling-role"
+  attach_policy_json = true
+  policy_json = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "rds:StopDBCluster",
+          "rds:StartDBCluster",
+        ],
+        Resource = [
+          module.aurora_db_app.cluster_arn,
+          module.aurora_db_feature_flags.cluster_arn,
+        ]
+      }
+    ]
+  })
+
+  schedules = {
+    # Scale up actions
+    "${local.prefix}-scheduled-start-app-db" = {
+      schedule_expression      = local.db_scale_up_cron_expression
+      timezone                 = local.timezone_london
+      use_flexible_time_window = false
+      arn                      = "arn:aws:scheduler:::aws-sdk:rds:startDBCluster"
+      input = jsonencode({ DbClusterIdentifier = module.aurora_db_app.cluster_id })
+    }
+    "${local.prefix}-scheduled-start-feature-flags-db" = {
+      schedule_expression      = local.db_scale_up_cron_expression
+      timezone                 = local.timezone_london
+      use_flexible_time_window = false
+      arn                      = "arn:aws:scheduler:::aws-sdk:rds:startDBCluster"
+      input = jsonencode({ DbClusterIdentifier = module.aurora_db_feature_flags.cluster_id })
+    }
+
+    # Scale down actions
+    "${local.prefix}-scheduled-stop-app-db" = {
+      schedule_expression      = local.db_scale_down_cron_expression
+      timezone                 = local.timezone_london
+      use_flexible_time_window = false
+      arn                      = "arn:aws:scheduler:::aws-sdk:rds:stopDBCluster"
+      input = jsonencode({ DbClusterIdentifier = module.aurora_db_app.cluster_id })
+    }
+    "${local.prefix}-scheduled-stop-feature-flags-db" = {
+      schedule_expression      = local.db_scale_down_cron_expression
+      timezone                 = local.timezone_london
+      use_flexible_time_window = false
+      arn                      = "arn:aws:scheduler:::aws-sdk:rds:stopDBCluster"
+      input = jsonencode({ DbClusterIdentifier = module.aurora_db_feature_flags.cluster_id })
+    }
+  }
+}
+

--- a/terraform/20-app/eventbridge.scheduled-scaling.tf
+++ b/terraform/20-app/eventbridge.scheduled-scaling.tf
@@ -31,14 +31,14 @@ module "eventbridge_scheduled_scaling" {
 
   schedules = {
     # Scale up actions
-    "${local.prefix}-scheduled-start-app-db" = {
+    "${local.prefix}-start-app-db" = {
       schedule_expression      = local.db_scale_up_cron_expression
       timezone                 = local.timezone_london
       use_flexible_time_window = false
       arn                      = "arn:aws:scheduler:::aws-sdk:rds:startDBCluster"
       input = jsonencode({ DbClusterIdentifier = module.aurora_db_app.cluster_id })
     }
-    "${local.prefix}-scheduled-start-feature-flags-db" = {
+    "${local.prefix}-start-feature-flags-db" = {
       schedule_expression      = local.db_scale_up_cron_expression
       timezone                 = local.timezone_london
       use_flexible_time_window = false
@@ -47,14 +47,14 @@ module "eventbridge_scheduled_scaling" {
     }
 
     # Scale down actions
-    "${local.prefix}-scheduled-stop-app-db" = {
+    "${local.prefix}-stop-app-db" = {
       schedule_expression      = local.db_scale_down_cron_expression
       timezone                 = local.timezone_london
       use_flexible_time_window = false
       arn                      = "arn:aws:scheduler:::aws-sdk:rds:stopDBCluster"
       input = jsonencode({ DbClusterIdentifier = module.aurora_db_app.cluster_id })
     }
-    "${local.prefix}-scheduled-stop-feature-flags-db" = {
+    "${local.prefix}-stop-feature-flags-db" = {
       schedule_expression      = local.db_scale_down_cron_expression
       timezone                 = local.timezone_london
       use_flexible_time_window = false


### PR DESCRIPTION
This PR does the following:

- Shuts down the db clusters 10 mins after the ECS container workloads in the evening
- Restarts the db clusters 30 mins before the container workloads in the morning
- Keeps the clusters offline over the weekend
- The above only applies to non-prod environments
- The staggered shutdown approach is so that the db clusters are always in a healthy state for the containers. Otherwise the containers can end up in a loop, crashing trying to connect to a db which isn't accepting connections