### PR TITLE
Add dedicated elasticache to private API for reserved / long-lived data so we can seperate it from ephemeral data in the existing redis cache

### DIFF
--- a/terraform/20-app/ecs.service.private-api.tf
+++ b/terraform/20-app/ecs.service.private-api.tf
@@ -173,6 +173,13 @@ module "ecs_service_private_api" {
       protocol                 = "tcp"
       source_security_group_id = module.app_elasticache_security_group.security_group_id
     }
+    reserved_cache_egress = {
+      type                     = "egress"
+      from_port                = 6379
+      to_port                  = 6379
+      protocol                 = "tcp"
+      source_security_group_id = module.private_api_elasticache_security_group.security_group_id
+    }
     internet_egress = {
       type        = "egress"
       from_port   = 443

--- a/terraform/20-app/ecs.service.private-api.tf
+++ b/terraform/20-app/ecs.service.private-api.tf
@@ -82,6 +82,10 @@ module "ecs_service_private_api" {
           value = "rediss://${aws_elasticache_serverless_cache.app_elasticache.endpoint.0.address}:${aws_elasticache_serverless_cache.app_elasticache.endpoint.0.port}"
         },
         {
+          name  = "REDIS_RESERVED_HOST"
+          value = "rediss://${aws_elasticache_serverless_cache.private_api_elasticache.endpoint.0.address}:${aws_elasticache_serverless_cache.private_api_elasticache.endpoint.0.port}"
+        },
+        {
           name  = "AUTH_ENABLED"
           value = local.auth_enabled
         },

--- a/terraform/20-app/ecs.service.utility-worker.tf
+++ b/terraform/20-app/ecs.service.utility-worker.tf
@@ -145,6 +145,13 @@ module "ecs_service_utility_worker" {
       protocol                 = "tcp"
       source_security_group_id = module.app_elasticache_security_group.security_group_id
     }
+    reserved_cache_egress = {
+      type                     = "egress"
+      from_port                = 6379
+      to_port                  = 6379
+      protocol                 = "tcp"
+      source_security_group_id = module.private_api_elasticache_security_group.security_group_id
+    }
     internet_egress = {
       type        = "egress"
       from_port   = 443

--- a/terraform/20-app/ecs.service.utility-worker.tf
+++ b/terraform/20-app/ecs.service.utility-worker.tf
@@ -76,7 +76,11 @@ module "ecs_service_utility_worker" {
           # The `rediss` prefix is not a typo
           # this is the redis-py native URL notation for an SSL wrapped TCP connection to redis
           value = "rediss://${aws_elasticache_serverless_cache.app_elasticache.endpoint.0.address}:${aws_elasticache_serverless_cache.app_elasticache.endpoint.0.port}"
-        }
+        },
+        {
+          name  = "REDIS_RESERVED_HOST"
+          value = "rediss://${aws_elasticache_serverless_cache.private_api_elasticache.endpoint.0.address}:${aws_elasticache_serverless_cache.private_api_elasticache.endpoint.0.port}"
+        },
       ],
       secrets = [
         {

--- a/terraform/20-app/ecs.service.worker.tf
+++ b/terraform/20-app/ecs.service.worker.tf
@@ -50,6 +50,10 @@ module "ecs_service_worker" {
           name  = "APIENV"
           value = "PROD"
         },
+        {
+          name  = "REDIS_RESERVED_HOST"
+          value = "rediss://${aws_elasticache_serverless_cache.private_api_elasticache.endpoint.0.address}:${aws_elasticache_serverless_cache.private_api_elasticache.endpoint.0.port}"
+        },
       ],
       secrets = [
         {
@@ -106,6 +110,13 @@ module "ecs_service_worker" {
       to_port                  = 5432
       protocol                 = "tcp"
       source_security_group_id = module.aurora_db_app.security_group_id
+    }
+    cache_egress = {
+      type                     = "egress"
+      from_port                = 6379
+      to_port                  = 6379
+      protocol                 = "tcp"
+      source_security_group_id = module.private_api_elasticache_security_group.security_group_id
     }
   }
 }

--- a/terraform/20-app/ecs.service.worker.tf
+++ b/terraform/20-app/ecs.service.worker.tf
@@ -111,7 +111,14 @@ module "ecs_service_worker" {
       protocol                 = "tcp"
       source_security_group_id = module.aurora_db_app.security_group_id
     }
-    cache_egress = {
+    default_cache_egress = {
+      type                     = "egress"
+      from_port                = 6379
+      to_port                  = 6379
+      protocol                 = "tcp"
+      source_security_group_id = module.app_elasticache_security_group.security_group_id
+    }
+    reserved_cache_egress = {
       type                     = "egress"
       from_port                = 6379
       to_port                  = 6379

--- a/terraform/20-app/elasticache.private-api.tf
+++ b/terraform/20-app/elasticache.private-api.tf
@@ -28,3 +28,39 @@ resource "aws_elasticache_serverless_cache" "app_elasticache" {
   security_group_ids       = [module.app_elasticache_security_group.security_group_id]
   subnet_ids               = module.vpc.elasticache_subnets
 }
+
+module "private_api_elasticache_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.3.0"
+
+  name   = "${local.prefix}-private-api-elasticache"
+  vpc_id = module.vpc.vpc_id
+
+  ingress_with_source_security_group_id = [
+    {
+      description              = "private api tasks to cache"
+      rule                     = "redis-tcp"
+      source_security_group_id = module.ecs_service_private_api.security_group_id
+    },
+    {
+      description              = "utility worker tasks to cache"
+      rule                     = "redis-tcp"
+      source_security_group_id = module.ecs_service_utility_worker.security_group_id
+    },
+    {
+      description              = "worker tasks to cache"
+      rule                     = "redis-tcp"
+      source_security_group_id = module.ecs_service_worker.security_group_id
+    }
+  ]
+}
+
+resource "aws_elasticache_serverless_cache" "private_api_elasticache" {
+  engine = "redis"
+  name   = "${local.prefix}-private-api"
+
+  major_engine_version     = "7"
+  snapshot_retention_limit = 1
+  security_group_ids       = [module.private_api_elasticache_security_group.security_group_id]
+  subnet_ids               = module.vpc.elasticache_subnets
+}


### PR DESCRIPTION
This PR does the following:

- Adds a new dedicated & physically seperate elasticache 
- Hooks this up to the private API and the workers

The AWS elasticache cluster mode limitation around the master node not really being a true master means that selective deletions / listing of keys in the cache won’t actually give you what you asked for, it will only give you keys for the node that you are currently connected to.

So a simple way around this is to seperate our ephemeral data (charts, tables, etc) from our long lived data (maps) into dedicated redis caches. They can scale independently of one another and we can then also clear the ephemeral cache with the `clear()` call which is a wrapper around the `FLUSHDB` redis command which will propagate the command to all shards in the cluster regardless of how far it has scaled out. Note that elasticache redis doesn't respect different database numbers in the same cluster. Everything is just put in db # 0, hence why I couldn't just keep the 1 redis cache but use seperate databases within it

