### PR TITLE
Drops the `auth-prod`, `auth-sandbox`, `test`, `auth-test`, `perf` & `auth-perf` environments from the CD pipeline

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -173,10 +173,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-  deploy_auth-prod:
-    needs: fast_forward_env_branches
-    uses: ./.github/workflows/production.auth.yml
-    secrets: inherit
+#  deploy_auth-prod:
+#    needs: fast_forward_env_branches
+#    uses: ./.github/workflows/production.auth.yml
+#    secrets: inherit
 
   deploy_dev:
     needs: fast_forward_env_branches
@@ -186,13 +186,13 @@ jobs:
       branch: env/dev/dev
     secrets: inherit
 
-  deploy_auth-sandbox:
-    needs: fast_forward_env_branches
-    if: ${{needs.fast_forward_env_branches.outputs.deploy_auth-sandbox}}
-    uses: ./.github/workflows/well-known-environment.yml
-    with:
-      branch: env/auth-dev/auth-sandbox
-    secrets: inherit
+#  deploy_auth-sandbox:
+#    needs: fast_forward_env_branches
+#    if: ${{needs.fast_forward_env_branches.outputs.deploy_auth-sandbox}}
+#    uses: ./.github/workflows/well-known-environment.yml
+#    with:
+#      branch: env/auth-dev/auth-sandbox
+#    secrets: inherit
 
   deploy_dpd:
     needs: fast_forward_env_branches
@@ -202,37 +202,37 @@ jobs:
       branch: env/dev/dpd
     secrets: inherit
 
-  deploy_test:
-    needs: fast_forward_env_branches
-    if: ${{needs.fast_forward_env_branches.outputs.deploy_test}}
-    uses: ./.github/workflows/well-known-environment.yml
-    with:
-      branch: env/test/test
-    secrets: inherit
+#  deploy_test:
+#    needs: fast_forward_env_branches
+#    if: ${{needs.fast_forward_env_branches.outputs.deploy_test}}
+#    uses: ./.github/workflows/well-known-environment.yml
+#    with:
+#      branch: env/test/test
+#    secrets: inherit
 
-  deploy_auth-test:
-    needs: fast_forward_env_branches
-    if: ${{needs.fast_forward_env_branches.outputs.deploy_auth-test}}
-    uses: ./.github/workflows/well-known-environment.yml
-    with:
-      branch: env/auth-test/auth-test
-    secrets: inherit
+#  deploy_auth-test:
+#    needs: fast_forward_env_branches
+#    if: ${{needs.fast_forward_env_branches.outputs.deploy_auth-test}}
+#    uses: ./.github/workflows/well-known-environment.yml
+#    with:
+#      branch: env/auth-test/auth-test
+#    secrets: inherit
 
-  deploy_perf:
-    needs: fast_forward_env_branches
-    if: ${{needs.fast_forward_env_branches.outputs.deploy_perf}}
-    uses: ./.github/workflows/well-known-environment.yml
-    with:
-      branch: env/test/perf
-    secrets: inherit
+#  deploy_perf:
+#    needs: fast_forward_env_branches
+#    if: ${{needs.fast_forward_env_branches.outputs.deploy_perf}}
+#    uses: ./.github/workflows/well-known-environment.yml
+#    with:
+#      branch: env/test/perf
+#    secrets: inherit
 
-  deploy_auth-perf:
-    needs: fast_forward_env_branches
-    if: ${{needs.fast_forward_env_branches.outputs.deploy_auth-perf}}
-    uses: ./.github/workflows/well-known-environment.yml
-    with:
-      branch: env/auth-test/auth-perf
-    secrets: inherit
+#  deploy_auth-perf:
+#    needs: fast_forward_env_branches
+#    if: ${{needs.fast_forward_env_branches.outputs.deploy_auth-perf}}
+#    uses: ./.github/workflows/well-known-environment.yml
+#    with:
+#      branch: env/auth-test/auth-perf
+#    secrets: inherit
 
   deploy_staging:
     needs: fast_forward_env_branches


### PR DESCRIPTION
This PR does the following:

- Drops the `auth-prod`, `auth-sandbox`, `test`, `auth-test`, `perf` & `auth-perf` environments from the CD pipeline
- Keeps the `dpd`, `dev`, `staging` and public dash `prod` environments on the CD pipeline

Once this goes in, I'll do a terraform destroy on the environments which have been dropped from the CD pipeline to save £££