### PR TITLE
CDD-2880: Offboard team September

### DIFF
--- a/terraform/20-app/ip-allow-lists.tf
+++ b/terraform/20-app/ip-allow-lists.tf
@@ -8,16 +8,8 @@ locals {
       "90.241.8.192/32",    # Rhys Inlaws
       "82.132.245.244/32",  # Rhys hotspot
       "86.2.63.107/32",     # Rhys Home
-      "86.173.151.83/32",    # Luke
+      "86.173.151.83/32",   # Luke
       "86.9.184.205/32",    # Manu
-      "147.161.237.5/32",   # Mike Elshaw
-      "147.161.236.91/32",  # Jeff Thomas - Windows
-      "81.106.144.243/32",  # Jeff Thomas - Macbook
-      "18.135.62.168/32",   # Load test rig
-      "18.133.111.70/32",   # Test gateway
-      "35.176.13.254/32",   # Test instance
-      "35.176.178.91/32",   # Test instance
-      "35.179.30.107/32",   # Test instance
     ],
     project_team = [
       "77.100.107.252/32",  # Laura


### PR DESCRIPTION
This PR does the following:
- Remove QA & performance testing team from IP allow list