### PR TITLE
Chore/bump aws provider and remaining tf modules

### DIFF
--- a/terraform/10-account/.terraform.lock.hcl
+++ b/terraform/10-account/.terraform.lock.hcl
@@ -2,26 +2,26 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.98.0"
-  constraints = ">= 2.49.0, >= 3.74.0, >= 4.0.0, >= 4.36.0, >= 4.40.0, >= 5.37.0, >= 5.49.0, >= 5.70.0, 5.98.0"
+  version     = "6.14.1"
+  constraints = ">= 2.49.0, >= 3.74.0, >= 4.0.0, >= 4.36.0, >= 4.40.0, >= 5.37.0, >= 5.49.0, >= 5.70.0, 6.14.1"
   hashes = [
-    "h1:KgOCdSG6euSc2lquuFlISJU/CzQTRhAO7WoaASxLZRc=",
-    "h1:neMFK/kP1KT6cTGID+Tkkt8L7PsN9XqwrPDGXVw3WVY=",
-    "h1:tfWnOmzoWOvwOGlUx0HrxCfUZq3YHhlkeEbMccAYiec=",
-    "zh:23377bd90204b6203b904f48f53edcae3294eb072d8fc18a4531c0cde531a3a1",
-    "zh:2e55a6ea14cc43b08cf82d43063e96c5c2f58ee953c2628523d0ee918fe3b609",
-    "zh:4885a817c16fdaaeddc5031edc9594c1f300db0e5b23be7cd76a473e7dcc7b4f",
-    "zh:6ca7177ad4e5c9d93dee4be1ac0792b37107df04657fddfe0c976f36abdd18b5",
-    "zh:78bf8eb0a67bae5dede09666676c7a38c9fb8d1b80a90ba06cf36ae268257d6f",
-    "zh:874b5a99457a3f88e2915df8773120846b63d820868a8f43082193f3dc84adcb",
-    "zh:95e1e4cf587cde4537ac9dfee9e94270652c812ab31fce3a431778c053abf354",
+    "h1:MWuQAmqVAUrH4cBihrFmDwo7weiAfXomKFEhd1Ew4PA=",
+    "h1:oacWXQzS6BmkN3lcKKxafYOGUQcUOpneJikw8hqLUyA=",
+    "h1:zhJy/Td/sbOHJ4SuxGYH8PCbTd+KCapfeDD/7Swd6SY=",
+    "zh:14d0b4b3dffb3368e6257136bbab1f93d419863dd65d99ef80ca2c1dd3c72a1e",
+    "zh:1de3601251f87a0a989c4b3474baa2efcaf491804f8d7afe15421b728bac5dc5",
+    "zh:2cfe42b853a3b4117bdbb73e5715035eac9b8d753d6e653fd5f30a807a36b985",
+    "zh:3dd8a0336face356928faf2396065634739ef2c3ac3dcaa655570df205559fd9",
+    "zh:42712baca386b84e089b1db8b7844038557f4039b32d8702611aa67eadef7d0f",
+    "zh:4ffc698099e4d7ffc6b0490a4e78ad66b041afd54e988b8bf8e229bcdd4b3ead",
+    "zh:52a6a3b01cb34394b0d06b273b27702fb9d795290a02e5824e198315787e8446",
+    "zh:56eae388c48a844401e44811719dc23be84de538468fd12b7265b06acbf4b51d",
+    "zh:614a918fdf27416b2ee2ce1737895b791f59f9deff3b61246c62a992eabfb8eb",
+    "zh:68605e159177b57fdc4a26bb2caff69a7b69593a601145b7ab5a86fd44b28b9f",
+    "zh:771ac00fd5f211052d735ff0e4b9ec67288abd1e22ffea4ed774aec73c7e5687",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a75145b58b241d64570803e6565c72467cd664633df32678755b51871f553e50",
-    "zh:aa31b13d0b0e8432940d6892a48b6268721fa54a02ed62ee42745186ee32f58d",
-    "zh:ae4565770f76672ce8e96528cbb66afdade1f91383123c079c7fdeafcb3d2877",
-    "zh:b99f042c45bf6aa69dd73f3f6d9cbe0b495b30442c526e0b3810089c059ba724",
-    "zh:bbb38e86d926ef101cefafe8fe090c57f2b1356eac9fc5ec81af310c50375897",
-    "zh:d03c89988ba4a0bd3cfc8659f951183ae7027aa8018a7ca1e53a300944af59cb",
-    "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
+    "zh:a1355841161e5b53dc3078c88aae1972fd4a9c0d30309b18b1951137b96571fa",
+    "zh:a3c8ca40c1fa7ad76d3d4c3c0039b66a93cc96399e757d2caa0b5cdedce9d3e8",
+    "zh:c77e02a72ef9eb0eb65faaf84c33af843520622dbb51ec31d04ca371bd4d4ee8",
   ]
 }

--- a/terraform/10-account/versions.tf
+++ b/terraform/10-account/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.98.0"
+      version = "6.14.1"
     }
   }
   required_version = ">= 1.4.5"

--- a/terraform/20-app/.terraform.lock.hcl
+++ b/terraform/20-app/.terraform.lock.hcl
@@ -2,27 +2,27 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.98.0"
-  constraints = ">= 3.29.0, >= 3.74.0, >= 4.66.1, >= 5.0.0, >= 5.12.0, >= 5.25.0, >= 5.32.0, >= 5.37.0, >= 5.46.0, >= 5.49.0, >= 5.58.0, >= 5.61.0, >= 5.70.0, >= 5.98.0, 5.98.0"
+  version     = "6.14.1"
+  constraints = ">= 3.29.0, >= 3.74.0, >= 4.66.1, >= 5.0.0, >= 5.12.0, >= 5.25.0, >= 5.32.0, >= 5.37.0, >= 5.49.0, >= 5.58.0, >= 5.61.0, >= 5.70.0, >= 5.98.0, >= 6.0.0, >= 6.5.0, >= 6.14.0, 6.14.1"
   hashes = [
-    "h1:KgOCdSG6euSc2lquuFlISJU/CzQTRhAO7WoaASxLZRc=",
-    "h1:neMFK/kP1KT6cTGID+Tkkt8L7PsN9XqwrPDGXVw3WVY=",
-    "h1:tfWnOmzoWOvwOGlUx0HrxCfUZq3YHhlkeEbMccAYiec=",
-    "zh:23377bd90204b6203b904f48f53edcae3294eb072d8fc18a4531c0cde531a3a1",
-    "zh:2e55a6ea14cc43b08cf82d43063e96c5c2f58ee953c2628523d0ee918fe3b609",
-    "zh:4885a817c16fdaaeddc5031edc9594c1f300db0e5b23be7cd76a473e7dcc7b4f",
-    "zh:6ca7177ad4e5c9d93dee4be1ac0792b37107df04657fddfe0c976f36abdd18b5",
-    "zh:78bf8eb0a67bae5dede09666676c7a38c9fb8d1b80a90ba06cf36ae268257d6f",
-    "zh:874b5a99457a3f88e2915df8773120846b63d820868a8f43082193f3dc84adcb",
-    "zh:95e1e4cf587cde4537ac9dfee9e94270652c812ab31fce3a431778c053abf354",
+    "h1:MWuQAmqVAUrH4cBihrFmDwo7weiAfXomKFEhd1Ew4PA=",
+    "h1:oacWXQzS6BmkN3lcKKxafYOGUQcUOpneJikw8hqLUyA=",
+    "h1:zhJy/Td/sbOHJ4SuxGYH8PCbTd+KCapfeDD/7Swd6SY=",
+    "zh:14d0b4b3dffb3368e6257136bbab1f93d419863dd65d99ef80ca2c1dd3c72a1e",
+    "zh:1de3601251f87a0a989c4b3474baa2efcaf491804f8d7afe15421b728bac5dc5",
+    "zh:2cfe42b853a3b4117bdbb73e5715035eac9b8d753d6e653fd5f30a807a36b985",
+    "zh:3dd8a0336face356928faf2396065634739ef2c3ac3dcaa655570df205559fd9",
+    "zh:42712baca386b84e089b1db8b7844038557f4039b32d8702611aa67eadef7d0f",
+    "zh:4ffc698099e4d7ffc6b0490a4e78ad66b041afd54e988b8bf8e229bcdd4b3ead",
+    "zh:52a6a3b01cb34394b0d06b273b27702fb9d795290a02e5824e198315787e8446",
+    "zh:56eae388c48a844401e44811719dc23be84de538468fd12b7265b06acbf4b51d",
+    "zh:614a918fdf27416b2ee2ce1737895b791f59f9deff3b61246c62a992eabfb8eb",
+    "zh:68605e159177b57fdc4a26bb2caff69a7b69593a601145b7ab5a86fd44b28b9f",
+    "zh:771ac00fd5f211052d735ff0e4b9ec67288abd1e22ffea4ed774aec73c7e5687",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a75145b58b241d64570803e6565c72467cd664633df32678755b51871f553e50",
-    "zh:aa31b13d0b0e8432940d6892a48b6268721fa54a02ed62ee42745186ee32f58d",
-    "zh:ae4565770f76672ce8e96528cbb66afdade1f91383123c079c7fdeafcb3d2877",
-    "zh:b99f042c45bf6aa69dd73f3f6d9cbe0b495b30442c526e0b3810089c059ba724",
-    "zh:bbb38e86d926ef101cefafe8fe090c57f2b1356eac9fc5ec81af310c50375897",
-    "zh:d03c89988ba4a0bd3cfc8659f951183ae7027aa8018a7ca1e53a300944af59cb",
-    "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
+    "zh:a1355841161e5b53dc3078c88aae1972fd4a9c0d30309b18b1951137b96571fa",
+    "zh:a3c8ca40c1fa7ad76d3d4c3c0039b66a93cc96399e757d2caa0b5cdedce9d3e8",
+    "zh:c77e02a72ef9eb0eb65faaf84c33af843520622dbb51ec31d04ca371bd4d4ee8",
   ]
 }
 

--- a/terraform/20-app/alb.cms-admin.tf
+++ b/terraform/20-app/alb.cms-admin.tf
@@ -1,6 +1,6 @@
 module "cms_admin_alb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "9.9.0"
+  version = "10.0.0"
 
   name = "${local.prefix}-cms-admin"
 

--- a/terraform/20-app/alb.feature-flags.tf
+++ b/terraform/20-app/alb.feature-flags.tf
@@ -1,6 +1,6 @@
 module "feature_flags_alb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "9.9.0"
+  version = "10.0.0"
 
   name = "${local.prefix}-feature-flags"
 
@@ -56,8 +56,9 @@ module "feature_flags_alb" {
           priority     = 1
           actions      = [
             {
-              type             = "forward"
-              target_group_key = "${local.prefix}-feature-flags"
+              forward = {
+                target_group_key = "${local.prefix}-feature-flags"
+              }
             }
           ]
           conditions = [

--- a/terraform/20-app/alb.feedback-api.tf
+++ b/terraform/20-app/alb.feedback-api.tf
@@ -1,6 +1,6 @@
 module "feedback_api_alb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "9.9.0"
+  version = "10.0.0"
 
   name = "${local.prefix}-feedback-api"
 
@@ -59,8 +59,9 @@ module "feedback_api_alb" {
           priority     = 1
           actions      = [
             {
-              type             = "forward"
-              target_group_key = "${local.prefix}-feedback-api"
+              forward = {
+                target_group_key = "${local.prefix}-feedback-api"
+              }
             }
           ]
           conditions = [

--- a/terraform/20-app/alb.front-end.tf
+++ b/terraform/20-app/alb.front-end.tf
@@ -1,6 +1,6 @@
 module "front_end_alb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "9.9.0"
+  version = "10.0.0"
 
   name = "${local.prefix}-front-end"
 
@@ -56,8 +56,9 @@ module "front_end_alb" {
           priority     = 1
           actions      = [
             {
-              type             = "forward"
-              target_group_key = "${local.prefix}-front-end"
+              forward = {
+                target_group_key = "${local.prefix}-front-end"
+              }
             }
           ]
           conditions = [

--- a/terraform/20-app/alb.private-api.tf
+++ b/terraform/20-app/alb.private-api.tf
@@ -1,6 +1,6 @@
 module "private_api_alb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "9.9.0"
+  version = "10.0.0"
 
   name = "${local.prefix}-private-api"
 
@@ -59,8 +59,9 @@ module "private_api_alb" {
           priority     = 1
           actions      = [
             {
-              type             = "forward"
-              target_group_key = "${local.prefix}-private-api"
+              forward = {
+                target_group_key = "${local.prefix}-private-api"
+              }
             }
           ]
           conditions = [

--- a/terraform/20-app/alb.public-api.tf
+++ b/terraform/20-app/alb.public-api.tf
@@ -1,6 +1,6 @@
 module "public_api_alb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "9.9.0"
+  version = "10.0.0"
 
   name = "${local.prefix}-public-api"
 
@@ -56,8 +56,9 @@ module "public_api_alb" {
           priority     = 1
           actions      = [
             {
-              type             = "forward"
-              target_group_key = "${local.prefix}-public-api"
+              forward = {
+                target_group_key = "${local.prefix}-public-api"
+              }
             }
           ]
           conditions = [

--- a/terraform/20-app/ecs.service.bastion.tf
+++ b/terraform/20-app/ecs.service.bastion.tf
@@ -1,6 +1,6 @@
 module "ecs_service_bastion" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
-  version = "5.11.4"
+  version = "6.4.0"
 
   name                   = "${local.prefix}-bastion"
   cluster_arn            = module.ecs.cluster_arn
@@ -42,8 +42,8 @@ module "ecs_service_bastion" {
     }
   ]
 
-  task_exec_iam_statements = {
-    kms_keys = {
+  task_exec_iam_statements = [
+    {
       actions   = ["kms:Decrypt"]
       resources = [
         module.kms_secrets_app_engineer.key_arn,
@@ -51,25 +51,22 @@ module "ecs_service_bastion" {
         module.kms_secrets_app_operator.key_arn,
       ]
     }
-  }
+  ]
 
-  security_group_rules = {
-    # egress rules
-    internet_https_egress = {
-      type        = "egress"
+  security_group_egress_rules = {
+    internet_https = {
       from_port   = 443
       to_port     = 443
       protocol    = "tcp"
       description = "https to internet"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_ipv4 = "0.0.0.0/0"
     }
-    internet_http_egress = {
-      type        = "egress"
+    internet_http = {
       from_port   = 80
       to_port     = 80
       protocol    = "tcp"
       description = "http to internet"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_ipv4 = "0.0.0.0/0"
     }
   }
 }

--- a/terraform/20-app/ecs.service.feedback-api.tf
+++ b/terraform/20-app/ecs.service.feedback-api.tf
@@ -1,6 +1,6 @@
 module "ecs_service_feedback_api" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
-  version = "5.11.4"
+  version = "6.4.0"
 
   name                   = "${local.prefix}-feedback-api"
   cluster_arn            = module.ecs.cluster_arn
@@ -35,9 +35,9 @@ module "ecs_service_feedback_api" {
       cpu                                    = local.use_prod_sizing ? 1024 : 512
       memory                                 = local.use_prod_sizing ? 2048 : 1024
       essential                              = true
-      readonly_root_filesystem               = true
+      readonlyRootFilesystem                = true
       image                                  = module.ecr_back_end_ecs.image_uri
-      mount_points                           = [
+      mountPoints                           = [
         {
           sourceVolume  = "tmp"
           containerPath = "/tmp"
@@ -49,7 +49,7 @@ module "ecs_service_feedback_api" {
           readOnly      = false
         }
       ]
-      port_mappings = [
+      portMappings = [
         {
           containerPort = 80
           hostPort      = 80
@@ -123,45 +123,41 @@ module "ecs_service_feedback_api" {
     }
   ]
 
-  task_exec_iam_statements = {
-    kms_keys = {
+  task_exec_iam_statements = [
+    {
       actions   = ["kms:Decrypt"]
       resources = [module.kms_secrets_app_engineer.key_arn]
     }
-  }
+  ]
 
-  security_group_rules = {
-    # ingress rules
-    alb_ingress = {
-      type                     = "ingress"
+  security_group_ingress_rules = {
+    alb = {
       from_port                = 80
       to_port                  = 80
       protocol                 = "tcp"
       description              = "lb to tasks"
-      source_security_group_id = module.feedback_api_alb.security_group_id
+      referenced_security_group_id = module.feedback_api_alb.security_group_id
     }
-    # egress rules
-    smtp_egress = {
-      type        = "egress"
+  }
+  security_group_egress_rules = {
+    smtp = {
       from_port   = 587
       to_port     = 587
       protocol    = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_ipv4 = "0.0.0.0/0"
     }
-    db_egress = {
-      type                     = "egress"
+    db = {
       from_port                = 5432
       to_port                  = 5432
       protocol                 = "tcp"
-      source_security_group_id = module.aurora_db_app.security_group_id
+      referenced_security_group_id = module.aurora_db_app.security_group_id
     }
-    internet_egress = {
-      type        = "egress"
+    internet = {
       from_port   = 443
       to_port     = 443
       protocol    = "tcp"
       description = "https to internet"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_ipv4 = "0.0.0.0/0"
     }
   }
 }

--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -1,6 +1,6 @@
 module "ecs_service_front_end" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
-  version = "5.11.4"
+  version = "6.4.0"
 
   name                   = "${local.prefix}-front-end"
   cluster_arn            = module.ecs.cluster_arn
@@ -35,16 +35,16 @@ module "ecs_service_front_end" {
       cpu                                    = local.use_prod_sizing ? 2048 : 512
       memory                                 = local.use_prod_sizing ? 4096 : 1024
       essential                              = true
-      readonly_root_filesystem               = true
+      readonlyRootFilesystem                = true
       image                                  = module.ecr_front_end_ecs.image_uri
-      mount_points = [
+      mountPoints = [
         {
           sourceVolume  = "tmp"
           containerPath = "/app/.next/cache"
           readOnly      = false
         }
       ]
-      port_mappings = [
+      portMappings = [
         {
           containerPort = 3000
           hostPort      = 3000
@@ -178,41 +178,38 @@ module "ecs_service_front_end" {
     }
   ]
 
-  task_exec_iam_statements = {
-    kms_keys = {
+  task_exec_iam_statements = [
+    {
       actions = ["kms:Decrypt"]
       resources = [
         module.kms_secrets_app_engineer.key_arn,
         module.kms_secrets_app_operator.key_arn,
       ]
     }
-  }
+  ]
 
-  security_group_rules = {
-    # ingress rules
-    alb_ingress = {
-      type                     = "ingress"
+  security_group_ingress_rules = {
+    alb = {
       from_port                = 3000
       to_port                  = 3000
       protocol                 = "tcp"
       description              = "lb to tasks"
-      source_security_group_id = module.front_end_alb.security_group_id
+      referenced_security_group_id = module.front_end_alb.security_group_id
     }
-    # egress rules
-    internet_egress = {
-      type        = "egress"
+  }
+  security_group_egress_rules = {
+    internet = {
       from_port   = 443
       to_port     = 443
       protocol    = "tcp"
       description = "https to internet"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_ipv4 = "0.0.0.0/0"
     },
-    cache_egress = {
-      type                     = "egress"
+    cache = {
       from_port                = 6379
       to_port                  = 6379
       protocol                 = "tcp"
-      source_security_group_id = module.front_end_elasticache_security_group.security_group_id
+      referenced_security_group_id = module.front_end_elasticache_security_group.security_group_id
     }
   }
 }

--- a/terraform/20-app/ecs.service.private-api.tf
+++ b/terraform/20-app/ecs.service.private-api.tf
@@ -1,6 +1,6 @@
 module "ecs_service_private_api" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
-  version = "5.11.4"
+  version = "6.4.0"
 
   name                   = "${local.prefix}-private-api"
   cluster_arn            = module.ecs.cluster_arn
@@ -37,9 +37,9 @@ module "ecs_service_private_api" {
       cpu                                    = local.use_prod_sizing ? 2048 : 512
       memory                                 = local.use_prod_sizing ? 4096 : 1024
       essential                              = true
-      readonly_root_filesystem               = true
+      readonlyRootFilesystem                = true
       image                                  = module.ecr_back_end_ecs.image_uri
-      mount_points = [
+      mountPoints = [
         {
           sourceVolume  = "tmp"
           containerPath = "/tmp"
@@ -51,7 +51,7 @@ module "ecs_service_private_api" {
           readOnly      = false
         }
       ]
-      port_mappings = [
+      portMappings = [
         {
           containerPort = 80
           hostPort      = 80
@@ -131,62 +131,57 @@ module "ecs_service_private_api" {
     }
   ]
 
-  task_exec_iam_statements = {
-    kms_keys = {
+  task_exec_iam_statements = [
+    {
       actions = ["kms:Decrypt"]
       resources = [
         module.kms_secrets_app_engineer.key_arn,
         module.kms_app_rds.key_arn
       ]
     }
-  }
+  ]
 
-  security_group_rules = {
-    # ingress rules
-    alb_ingress = {
-      type                     = "ingress"
+  security_group_ingress_rules = {
+    alb = {
       from_port                = 80
       to_port                  = 80
       protocol                 = "tcp"
       description              = "lb to tasks"
-      source_security_group_id = module.private_api_alb.security_group_id
+      referenced_security_group_id = module.private_api_alb.security_group_id
     }
-    bastion_ingress = {
-      type                     = "ingress"
+    bastion = {
       from_port                = 80
       to_port                  = 80
       protocol                 = "tcp"
-      source_security_group_id = module.ecs_service_bastion.security_group_id
+      referenced_security_group_id = module.ecs_service_bastion.security_group_id
     }
-    # egress rules
-    db_egress = {
-      type                     = "egress"
+  }
+
+  security_group_egress_rules = {
+    db = {
       from_port                = 5432
       to_port                  = 5432
       protocol                 = "tcp"
-      source_security_group_id = module.aurora_db_app.security_group_id
+      referenced_security_group_id = module.aurora_db_app.security_group_id
     }
-    cache_egress = {
-      type                     = "egress"
+    cache = {
       from_port                = 6379
       to_port                  = 6379
       protocol                 = "tcp"
-      source_security_group_id = module.app_elasticache_security_group.security_group_id
+      referenced_security_group_id = module.app_elasticache_security_group.security_group_id
     }
-    reserved_cache_egress = {
-      type                     = "egress"
+    reserved_cache = {
       from_port                = 6379
       to_port                  = 6379
       protocol                 = "tcp"
-      source_security_group_id = module.private_api_elasticache_security_group.security_group_id
+      referenced_security_group_id = module.private_api_elasticache_security_group.security_group_id
     }
-    internet_egress = {
-      type        = "egress"
+    internet = {
       from_port   = 443
       to_port     = 443
       protocol    = "tcp"
       description = "https to internet"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_ipv4 = "0.0.0.0/0"
     }
   }
 }

--- a/terraform/20-app/ecs.service.public-api.tf
+++ b/terraform/20-app/ecs.service.public-api.tf
@@ -1,6 +1,6 @@
 module "ecs_service_public_api" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
-  version = "5.11.4"
+  version = "6.4.0"
 
   name                   = "${local.prefix}-public-api"
   cluster_arn            = module.ecs.cluster_arn
@@ -35,9 +35,9 @@ module "ecs_service_public_api" {
       cpu                                    = local.use_prod_sizing ? 1024 : 512
       memory                                 = local.use_prod_sizing ? 2048 : 1024
       essential                              = true
-      readonly_root_filesystem               = true
+      readonlyRootFilesystem                = true
       image                                  = module.ecr_back_end_ecs.image_uri
-      mount_points = [
+      mountPoints = [
         {
           sourceVolume  = "tmp"
           containerPath = "/tmp"
@@ -49,7 +49,7 @@ module "ecs_service_public_api" {
           readOnly      = false
         }
       ]
-      port_mappings = [
+      portMappings = [
         {
           containerPort = 80
           hostPort      = 80
@@ -119,41 +119,38 @@ module "ecs_service_public_api" {
     }
   ]
 
-  task_exec_iam_statements = {
-    kms_keys = {
+  task_exec_iam_statements = [
+    {
       actions = ["kms:Decrypt"]
       resources = [
         module.kms_secrets_app_engineer.key_arn,
         module.kms_app_rds.key_arn
       ]
     }
-  }
+  ]
 
-  security_group_rules = {
-    # ingress rules
-    alb_ingress = {
-      type                     = "ingress"
+  security_group_ingress_rules = {
+    alb = {
       from_port                = 80
       to_port                  = 80
       protocol                 = "tcp"
       description              = "lb to tasks"
-      source_security_group_id = module.public_api_alb.security_group_id
+      referenced_security_group_id = module.public_api_alb.security_group_id
     }
-    # egress rules
-    db_egress = {
-      type                     = "egress"
+  }
+  security_group_egress_rules = {
+    db = {
       from_port                = 5432
       to_port                  = 5432
       protocol                 = "tcp"
-      source_security_group_id = module.aurora_db_app.security_group_id
+      referenced_security_group_id = module.aurora_db_app.security_group_id
     }
-    internet_egress = {
-      type        = "egress"
+    internet = {
       from_port   = 443
       to_port     = 443
       protocol    = "tcp"
       description = "https to internet"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_ipv4 = "0.0.0.0/0"
     }
   }
 }

--- a/terraform/20-app/ecs.service.utility-worker.tf
+++ b/terraform/20-app/ecs.service.utility-worker.tf
@@ -1,6 +1,6 @@
 module "ecs_service_utility_worker" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
-  version = "5.11.4"
+  version = "6.4.0"
 
   name                   = "${local.prefix}-utility-worker"
   cluster_arn            = module.ecs.cluster_arn
@@ -33,9 +33,9 @@ module "ecs_service_utility_worker" {
       cpu                                    = 16384
       memory                                 = 32768
       essential                              = true
-      readonly_root_filesystem               = true
+      readonlyRootFilesystem                = true
       image                                  = module.ecr_back_end_ecs.image_uri
-      mount_points                           = [
+      mountPoints                           = [
         {
           sourceVolume  = "tmp"
           containerPath = "/tmp"
@@ -47,7 +47,7 @@ module "ecs_service_utility_worker" {
           readOnly      = false
         }
       ]
-      port_mappings = [
+      portMappings = [
         {
           containerPort = 80
           hostPort      = 80
@@ -111,54 +111,49 @@ module "ecs_service_utility_worker" {
     }
   ]
 
-  task_exec_iam_statements = {
-    kms_keys = {
+  task_exec_iam_statements = [
+    {
       actions   = ["kms:Decrypt"]
       resources = [
         module.kms_secrets_app_engineer.key_arn,
         module.kms_app_rds.key_arn
       ]
     }
-  }
+  ]
 
-  security_group_rules = {
-    # ingress rules
+  security_group_ingress_rules = {
     alb_ingress = {
-      type                     = "ingress"
       from_port                = 80
       to_port                  = 80
       protocol                 = "tcp"
-      source_security_group_id = module.private_api_alb.security_group_id
+      referenced_security_group_id = module.private_api_alb.security_group_id
     }
-    # egress rules
-    db_egress = {
-      type                     = "egress"
+  }
+  security_group_egress_rules = {
+    db = {
       from_port                = 5432
       to_port                  = 5432
       protocol                 = "tcp"
-      source_security_group_id = module.aurora_db_app.security_group_id
+      referenced_security_group_id = module.aurora_db_app.security_group_id
     }
-    cache_egress = {
-      type                     = "egress"
+    cache = {
       from_port                = 6379
       to_port                  = 6379
       protocol                 = "tcp"
-      source_security_group_id = module.app_elasticache_security_group.security_group_id
+      referenced_security_group_id = module.app_elasticache_security_group.security_group_id
     }
-    reserved_cache_egress = {
-      type                     = "egress"
+    reserved_cache = {
       from_port                = 6379
       to_port                  = 6379
       protocol                 = "tcp"
-      source_security_group_id = module.private_api_elasticache_security_group.security_group_id
+      referenced_security_group_id = module.private_api_elasticache_security_group.security_group_id
     }
-    internet_egress = {
-      type        = "egress"
+    internet = {
       from_port   = 443
       to_port     = 443
       protocol    = "tcp"
       description = "https to internet"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_ipv4 = "0.0.0.0/0"
     }
   }
 }

--- a/terraform/20-app/ecs.service.worker.tf
+++ b/terraform/20-app/ecs.service.worker.tf
@@ -1,6 +1,6 @@
 module "ecs_service_worker" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
-  version = "5.11.4"
+  version = "6.4.0"
 
   name                   = "${local.prefix}-worker"
   cluster_arn            = module.ecs.cluster_arn
@@ -84,46 +84,41 @@ module "ecs_service_worker" {
     }
   ]
 
-  task_exec_iam_statements = {
-    kms_keys = {
+  task_exec_iam_statements = [
+    {
       actions   = ["kms:Decrypt"]
       resources = [
         module.kms_secrets_app_engineer.key_arn,
         module.kms_app_rds.key_arn,
       ]
     }
-  }
+  ]
 
-  security_group_rules = {
-    # egress rules
-    internet_egress = {
-      type        = "egress"
+  security_group_egress_rules = {
+    internet = {
       from_port   = 443
       to_port     = 443
       protocol    = "tcp"
       description = "https to internet"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_ipv4 = "0.0.0.0/0"
     }
-    db_egress = {
-      type                     = "egress"
+    db = {
       from_port                = 5432
       to_port                  = 5432
       protocol                 = "tcp"
-      source_security_group_id = module.aurora_db_app.security_group_id
+      referenced_security_group_id = module.aurora_db_app.security_group_id
     }
-    default_cache_egress = {
-      type                     = "egress"
+    default_cache = {
       from_port                = 6379
       to_port                  = 6379
       protocol                 = "tcp"
-      source_security_group_id = module.app_elasticache_security_group.security_group_id
+      referenced_security_group_id = module.app_elasticache_security_group.security_group_id
     }
-    reserved_cache_egress = {
-      type                     = "egress"
+    reserved_cache = {
       from_port                = 6379
       to_port                  = 6379
       protocol                 = "tcp"
-      source_security_group_id = module.private_api_elasticache_security_group.security_group_id
+      referenced_security_group_id = module.private_api_elasticache_security_group.security_group_id
     }
   }
 }

--- a/terraform/20-app/ecs.tf
+++ b/terraform/20-app/ecs.tf
@@ -1,6 +1,6 @@
 module "ecs" {
   source  = "terraform-aws-modules/ecs/aws"
-  version = "5.11.4"
+  version = "6.4.0"
 
   cluster_name = "${local.prefix}-cluster"
 }

--- a/terraform/20-app/versions.tf
+++ b/terraform/20-app/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.98.0"
+      version = "6.14.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/20-app/vpc.tf
+++ b/terraform/20-app/vpc.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "5.12.1"
+  version = "6.2.0"
 
   name = "${local.prefix}-main"
   cidr = "10.0.0.0/16"


### PR DESCRIPTION
This PR does the following:
 
- Bumps the AWS provider to the latest version (6.14.1)
- Bumps the alb terraform module to the latest version (10.0.0)
- Bumps the ecs terraform module to the latest version (6.4.0)
- Bumps the vpc terraform module to the latest version (6.2.0)