### PR TITLE
chore: prevent dpd and staging from scaling down

### DIFF
--- a/terraform/20-app/locals.tf
+++ b/terraform/20-app/locals.tf
@@ -33,7 +33,7 @@ locals {
   is_dev                                       = contains(["dev", "auth-dev"], var.environment_type)
   is_prod                                      = local.environment == "prod"
   is_ready_for_etl                             = contains(["dev", "test", "dpd", "staging", "prod"], local.environment)
-  is_scaled_down_overnight                     = !contains(["prod"], local.environment)
+  is_scaled_down_overnight                     = !contains(["prod", "dpd", "staging"], local.environment)
   timezone_london                              = "Europe/London"
   use_ip_allow_list                            = local.environment != "prod"
 


### PR DESCRIPTION
To support any potential work needed for the Hantavirus incident, DPD have requested access to staging and the dpd-dev site out of hours.