### PR TITLE
Update actions node runtime [cdd-3229]

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -48,7 +48,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials for tools account
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       if: ${{ inputs.account-name == 'tools' }}
       with:
         role-to-assume: ${{ inputs.tools-account-role }}
@@ -56,7 +56,7 @@ runs:
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for prod account
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       if: ${{ inputs.account-name == 'prod' }}
       with:
         role-to-assume: ${{ inputs.prod-account-role }}
@@ -65,7 +65,7 @@ runs:
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for dev account
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       if: ${{ contains(fromJSON('["dev", "dpd"]'), inputs.account-name) }}
       with:
         role-to-assume: ${{ inputs.dev-account-role }}
@@ -74,7 +74,7 @@ runs:
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for auth-dev account
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       if: ${{ contains(fromJSON('["auth-dev", "auth-dpd", "auth-sandbox"]'), inputs.account-name) }}
       with:
         role-to-assume: ${{ inputs.auth-dev-account-role }}
@@ -83,7 +83,7 @@ runs:
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for test account
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       if: ${{ contains(fromJSON('["test", "perf"]'), inputs.account-name) }}
       with:
         role-to-assume: ${{ inputs.test-account-role }}
@@ -92,7 +92,7 @@ runs:
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for auth-test account
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       if: ${{ contains(fromJSON('["auth-test", "auth-perf"]'), inputs.account-name) }}
       with:
         role-to-assume: ${{ inputs.auth-test-account-role }}
@@ -101,7 +101,7 @@ runs:
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for uat account
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       if: ${{ contains(fromJSON('["uat", "staging"]'), inputs.account-name) }}
       with:
         role-to-assume: ${{ inputs.uat-account-role }}
@@ -110,7 +110,7 @@ runs:
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for auth uat account
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       if: ${{ inputs.account-name == 'auth-uat' }}
       with:
         role-to-assume: ${{ inputs.auth-uat-account-role }}
@@ -119,7 +119,7 @@ runs:
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: Configure AWS credentials for auth prod account
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       if: ${{ inputs.account-name == 'auth-prod' }}
       with:
         role-to-assume: ${{ inputs.auth-prod-account-role }}

--- a/.github/actions/npm-test/action.yml
+++ b/.github/actions/npm-test/action.yml
@@ -22,13 +22,13 @@ runs:
       working-directory: ./src/${{inputs.function-name}}
 
     - name: Cache unit test summary
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: ${{inputs.function-name}}-coverage-summary
         path: ./src/${{inputs.function-name}}/coverage/coverage-summary.json
 
     - name: Cache unit test report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: ${{inputs.function-name}}-coverage-report
         path: ./src/${{inputs.function-name}}/junit.xml

--- a/.github/workflows/cleanup-ci-test-environments.yml
+++ b/.github/workflows/cleanup-ci-test-environments.yml
@@ -17,7 +17,7 @@ jobs:
     name: Cleanup test environments
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh
 

--- a/.github/workflows/create-ancillary-test-environment.yml
+++ b/.github/workflows/create-ancillary-test-environment.yml
@@ -24,7 +24,7 @@ jobs:
     name: Terraform apply
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_apply"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["push_docker_images"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_re_apply"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ "restart_services" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["bootstrap_database"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh
 

--- a/.github/workflows/create-ancillary-test-environment.yml
+++ b/.github/workflows/create-ancillary-test-environment.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -71,7 +71,7 @@ jobs:
     needs: ["push_docker_images"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/create-personal-dev-environment.auth.yml
+++ b/.github/workflows/create-personal-dev-environment.auth.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["validate_environment_name"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_apply"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["push_docker_images"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_re_apply"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ "restart_services" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/create-personal-dev-environment.auth.yml
+++ b/.github/workflows/create-personal-dev-environment.auth.yml
@@ -43,7 +43,7 @@ jobs:
     needs: ["validate_environment_name"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -89,7 +89,7 @@ jobs:
     needs: ["push_docker_images"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/create-personal-dev-environment.yml
+++ b/.github/workflows/create-personal-dev-environment.yml
@@ -38,7 +38,7 @@ jobs:
     needs: ["validate_environment_name"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -84,7 +84,7 @@ jobs:
     needs: ["push_docker_images"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/create-personal-dev-environment.yml
+++ b/.github/workflows/create-personal-dev-environment.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["validate_environment_name"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_apply"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["push_docker_images"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_re_apply"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ "restart_services" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["bootstrap_database"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh
 

--- a/.github/workflows/deploy-personal-dev-environment.auth.yml
+++ b/.github/workflows/deploy-personal-dev-environment.auth.yml
@@ -103,7 +103,7 @@ jobs:
           path: data-dashboard-infra
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -151,7 +151,7 @@ jobs:
           path: data-dashboard-infra
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -199,7 +199,7 @@ jobs:
           path: data-dashboard-infra
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-personal-dev-environment.auth.yml
+++ b/.github/workflows/deploy-personal-dev-environment.auth.yml
@@ -106,7 +106,7 @@ jobs:
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Build frontend image
         run: |
@@ -154,7 +154,7 @@ jobs:
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Build backend image
         run: |
@@ -202,7 +202,7 @@ jobs:
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Build ingestion image
         run: |

--- a/.github/workflows/deploy-personal-dev-environment.auth.yml
+++ b/.github/workflows/deploy-personal-dev-environment.auth.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout infra repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/deploy-personal-dev-environment.auth.yml
+++ b/.github/workflows/deploy-personal-dev-environment.auth.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -50,7 +50,7 @@ jobs:
     needs: [ "validate_environment_name" ]
     steps:
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: actions/setup-python@v6
 
@@ -77,7 +77,7 @@ jobs:
     needs: [ "terraform_apply" ]
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -91,14 +91,14 @@ jobs:
       - uses: ./.github/actions/setup-zsh
 
       - name: Checkout frontend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: UKHSA-Internal/data-dashboard-frontend
           path: data-dashboard-frontend
           ref: ${{ inputs.frontend_branch }}
 
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           path: data-dashboard-infra
 
@@ -125,7 +125,7 @@ jobs:
     needs: [ "terraform_apply" ]
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -139,14 +139,14 @@ jobs:
       - uses: ./.github/actions/setup-zsh
 
       - name: Checkout backend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: UKHSA-Internal/data-dashboard-api
           path: data-dashboard-api
           ref: ${{ inputs.backend_branch }}
 
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           path: data-dashboard-infra
 
@@ -173,7 +173,7 @@ jobs:
     needs: [ "terraform_apply" ]
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -187,14 +187,14 @@ jobs:
       - uses: ./.github/actions/setup-zsh
 
       - name: Checkout backend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: UKHSA-Internal/data-dashboard-api
           path: data-dashboard-api
           ref: ${{ inputs.ingestion_branch }}
 
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           path: data-dashboard-infra
 
@@ -226,7 +226,7 @@ jobs:
       ]
     steps:
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -103,7 +103,7 @@ jobs:
           path: data-dashboard-infra
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -151,7 +151,7 @@ jobs:
           path: data-dashboard-infra
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -199,7 +199,7 @@ jobs:
           path: data-dashboard-infra
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -106,7 +106,7 @@ jobs:
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Build frontend image
         run: |
@@ -154,7 +154,7 @@ jobs:
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Build backend image
         run: |
@@ -202,7 +202,7 @@ jobs:
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Build ingestion image
         run: |

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout infra repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/deploy-personal-dev-environment.yml
+++ b/.github/workflows/deploy-personal-dev-environment.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -50,7 +50,7 @@ jobs:
     needs: ["validate_environment_name"]
     steps:
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: actions/setup-python@v6
 
@@ -77,7 +77,7 @@ jobs:
     needs: ["terraform_apply"]
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -91,14 +91,14 @@ jobs:
       - uses: ./.github/actions/setup-zsh
 
       - name: Checkout frontend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: UKHSA-Internal/data-dashboard-frontend
           path: data-dashboard-frontend
           ref: ${{ inputs.frontend_branch }}
 
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           path: data-dashboard-infra
 
@@ -125,7 +125,7 @@ jobs:
     needs: [ "terraform_apply" ]
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -139,14 +139,14 @@ jobs:
       - uses: ./.github/actions/setup-zsh
 
       - name: Checkout backend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: UKHSA-Internal/data-dashboard-api
           path: data-dashboard-api
           ref: ${{ inputs.backend_branch }}
 
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           path: data-dashboard-infra
 
@@ -173,7 +173,7 @@ jobs:
     needs: [ "terraform_apply" ]
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -187,14 +187,14 @@ jobs:
       - uses: ./.github/actions/setup-zsh
 
       - name: Checkout backend repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: UKHSA-Internal/data-dashboard-api
           path: data-dashboard-api
           ref: ${{ inputs.ingestion_branch }}
 
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           path: data-dashboard-infra
 
@@ -226,7 +226,7 @@ jobs:
       ]
     steps:
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -269,7 +269,7 @@ jobs:
     needs: ["restart_services"]
     steps:
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh

--- a/.github/workflows/flush-cache-reserved-namespace-dev-environment.yml
+++ b/.github/workflows/flush-cache-reserved-namespace-dev-environment.yml
@@ -21,7 +21,7 @@ jobs:
     name: Flush caches
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh
 

--- a/.github/workflows/flush-cache-reserved-namespace-well-known-environment.yml
+++ b/.github/workflows/flush-cache-reserved-namespace-well-known-environment.yml
@@ -28,7 +28,7 @@ jobs:
     name: Flush caches
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh
 

--- a/.github/workflows/flush-caches-dev-environment.yml
+++ b/.github/workflows/flush-caches-dev-environment.yml
@@ -21,7 +21,7 @@ jobs:
     name: Update caches
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh
 

--- a/.github/workflows/flush-caches-well-known-environment.yml
+++ b/.github/workflows/flush-caches-well-known-environment.yml
@@ -28,7 +28,7 @@ jobs:
     name: Update caches
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-terraform
       - uses: ./.github/actions/setup-zsh
 

--- a/.github/workflows/production.auth.yml
+++ b/.github/workflows/production.auth.yml
@@ -20,7 +20,7 @@ jobs:
     name: Terraform plan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
       - uses: actions/setup-python@v6
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_plan"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
       - uses: actions/setup-python@v6
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_apply"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
 
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["push_docker_images"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
 

--- a/.github/workflows/production.auth.yml
+++ b/.github/workflows/production.auth.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,7 +26,7 @@ jobs:
     name: Terraform plan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_plan"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_apply"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["push_docker_images"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Generate ephemeral Github auth token
         id: generate-auth-token
         uses: actions/create-github-app-token@v2
@@ -171,7 +171,7 @@ jobs:
       deploy_auth-perf: ${{ steps.fast_forward_merge.outputs.deploy_auth-perf }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -52,7 +52,7 @@ jobs:
     needs: ["terraform_plan"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -145,7 +145,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Generate ephemeral Github auth token
         id: generate-auth-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_APP_ID }}
           private-key: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_PRIVATE_KEY }}

--- a/.github/workflows/pull-request.auth.yml
+++ b/.github/workflows/pull-request.auth.yml
@@ -131,7 +131,7 @@ jobs:
     needs: ["build_base_auth", "unit_test_functions_auth"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -157,7 +157,7 @@ jobs:
     needs: ["build_base_auth", "terraform_plan_auth"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -249,7 +249,7 @@ jobs:
     needs: ["restart_services_auth"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/pull-request.auth.yml
+++ b/.github/workflows/pull-request.auth.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ github.base_ref }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
         with:
           role-to-assume: ${{ secrets.UHD_TERRAFORM_IAM_ROLE }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/pull-request.auth.yml
+++ b/.github/workflows/pull-request.auth.yml
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Download test coverage
-        uses: actions/download-artifact@v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: ./reports
 

--- a/.github/workflows/pull-request.auth.yml
+++ b/.github/workflows/pull-request.auth.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build base env
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.base_ref }}
 
@@ -47,7 +47,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install node
         uses: actions/setup-node@v6
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["build_base_auth", "unit_test_functions_auth"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["build_base_auth", "terraform_plan_auth"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_apply_auth"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["push_docker_images_auth"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -248,7 +248,7 @@ jobs:
     if: ${{ always() }}
     needs: ["restart_services_auth"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -274,7 +274,7 @@ jobs:
     if: ${{ always() }}
     needs: ["terraform_destroy_auth"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/pull-request.auth.yml
+++ b/.github/workflows/pull-request.auth.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: './.nvmrc'
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,7 +41,7 @@ jobs:
           ref: ${{ github.base_ref }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
         with:
           role-to-assume: ${{ secrets.UHD_TERRAFORM_IAM_ROLE }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -176,7 +176,7 @@ jobs:
     needs: ["build_base", "unit_test_functions"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -202,7 +202,7 @@ jobs:
     needs: ["build_base", "terraform_plan"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -294,7 +294,7 @@ jobs:
     needs: ["restart_services"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
     needs: [secret-scan]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.base_ref }}
 
@@ -66,7 +66,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install node
         uses: actions/setup-node@v6
@@ -92,7 +92,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install node
         uses: actions/setup-node@v6
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["build_base", "unit_test_functions"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["build_base", "terraform_plan"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -227,7 +227,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_apply"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -249,7 +249,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["push_docker_images"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -293,7 +293,7 @@ jobs:
     if: ${{ always() }}
     needs: ["restart_services"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -319,7 +319,7 @@ jobs:
     if: ${{ always() }}
     needs: ["terraform_destroy"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -145,7 +145,7 @@ jobs:
 
     steps:
       - name: Download test coverage
-        uses: actions/download-artifact@v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: ./reports
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: './.nvmrc'
 
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: './.nvmrc'
 

--- a/.github/workflows/teardown-ancillary-test-environment.yml
+++ b/.github/workflows/teardown-ancillary-test-environment.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -62,7 +62,7 @@ jobs:
     needs: ["remove_db_deletion_protections"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/teardown-ancillary-test-environment.yml
+++ b/.github/workflows/teardown-ancillary-test-environment.yml
@@ -24,7 +24,7 @@ jobs:
     name: Remove DB deletion protections
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["remove_db_deletion_protections"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_destroy"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/teardown-dev-environment.yml
+++ b/.github/workflows/teardown-dev-environment.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout .github/ directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           sparse-checkout: |
             .github
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ "validate_environment_name" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["remove_db_deletion_protections"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-python@v6
 
       - name: Configure AWS credentials for tools account
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_destroy"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/teardown-dev-environment.yml
+++ b/.github/workflows/teardown-dev-environment.yml
@@ -38,7 +38,7 @@ jobs:
     needs: [ "validate_environment_name" ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -76,7 +76,7 @@ jobs:
     needs: ["remove_db_deletion_protections"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/well-known-environment.yml
+++ b/.github/workflows/well-known-environment.yml
@@ -23,7 +23,7 @@ jobs:
     name: Terraform plan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
       - uses: actions/setup-python@v6
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_plan"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
       - uses: actions/setup-python@v6
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["terraform_apply"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
 
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["push_docker_images"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
 

--- a/.github/workflows/well-known-environment.yml
+++ b/.github/workflows/well-known-environment.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ env.branch }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
 
       - name: Configure AWS credentials for tools account
         uses: ./.github/actions/configure-aws-credentials


### PR DESCRIPTION
Upgrade as many action dependencies as we can to remove node 20 deprecation warnings. E.g. https://github.com/UKHSA-Internal/data-dashboard-infra/actions/runs/26643327775 which looks like this:

<img width="1473" height="741" alt="image" src="https://github.com/user-attachments/assets/f5a49775-f8c0-4b8a-a16d-e5e61eb85d3e" />

Git leaks is still lacking node 20 support (e.g. https://github.com/gitleaks/gitleaks-action/issues/209) however it does work when running against node 24 (this has been tested [here](https://github.com/UKHSA-Internal/data-dashboard-api/actions/runs/26645443353). If it becomes an issue in the future, we'll turn it off / look for another way of running it.

`ukhsa-internal/jest-coverage-comment-action@v1` is super old and needs to be updated or better yet probably removed. It does work with node 24 though so we'll deal with that outside of this ticket (tested [here](https://github.com/UKHSA-Internal/data-dashboard-infra/actions/runs/26748642117/job/78830752564)).

Note that every action has been upgraded to the latest version available but we use the sha of the commit that was released for [security reasons](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). This is also ensures we pass the sonarqube checks.

Fixes #CDD-3229

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Tech debt item (this is focused solely on addressing any relevant technical debt)
