### PR TITLE
dpd-dev sizing increase

### DIFF
--- a/terraform/20-app/ecs.service.bastion.tf
+++ b/terraform/20-app/ecs.service.bastion.tf
@@ -1,3 +1,10 @@
+locals {
+  bastion_sizing = {
+    cpu    = 256
+    memory = 512
+  }
+}
+
 module "ecs_service_bastion" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "6.10.0"
@@ -6,8 +13,8 @@ module "ecs_service_bastion" {
   cluster_arn            = module.ecs.cluster_arn
   enable_execute_command = true
 
-  cpu        = 256
-  memory     = 512
+  cpu        = local.bastion_sizing.cpu
+  memory     = local.bastion_sizing.memory
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling = false
@@ -22,10 +29,10 @@ module "ecs_service_bastion" {
     bastion = {
       cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
       command = ["sleep", "infinity"]
-      cpu                                    = 256
+      cpu                                    = local.bastion_sizing.cpu
+      memory                                 = local.bastion_sizing.memory
       essential                              = true
       image                                  = "public.ecr.aws/amazonlinux/amazonlinux:2023"
-      memory                                 = 512
       readonly_root_filesystem               = false
     }
   }

--- a/terraform/20-app/ecs.service.cms-admin.tf
+++ b/terraform/20-app/ecs.service.cms-admin.tf
@@ -1,7 +1,7 @@
 locals {
   cms_sizing = {
-    cpu    = local.use_prod_sizing ? 2048 : 512
-    memory = local.use_prod_sizing ? 4096 : 1024
+    cpu    = local.use_prod_sizing ? 2048 : local.use_mid_sizing ? 1024 : 512
+    memory = local.use_prod_sizing ? 4096 : local.use_mid_sizing ? 2048 : 1024
   }
 }
 

--- a/terraform/20-app/ecs.service.cms-admin.tf
+++ b/terraform/20-app/ecs.service.cms-admin.tf
@@ -1,3 +1,10 @@
+locals {
+  cms_sizing = {
+    cpu    = local.use_prod_sizing ? 2048 : 512
+    memory = local.use_prod_sizing ? 4096 : 1024
+  }
+}
+
 module "ecs_service_cms_admin" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "6.10.0"
@@ -6,8 +13,8 @@ module "ecs_service_cms_admin" {
   cluster_arn            = module.ecs.cluster_arn
   enable_execute_command = true
 
-  cpu        = local.use_prod_sizing ? 2048 : 512
-  memory     = local.use_prod_sizing ? 4096 : 1024
+  cpu        = local.cms_sizing.cpu
+  memory     = local.cms_sizing.memory
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
@@ -32,8 +39,8 @@ module "ecs_service_cms_admin" {
   container_definitions = {
     api = {
       cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
-      cpu                                    = local.use_prod_sizing ? 2048 : 512
-      memory                                 = local.use_prod_sizing ? 4096 : 1024
+      cpu                                    = local.cms_sizing.cpu
+      memory                                 = local.cms_sizing.memory
       essential                              = true
       readonlyRootFilesystem                 = true
       image                                  = module.ecr_back_end_ecs.image_uri

--- a/terraform/20-app/ecs.service.feature-flags.tf
+++ b/terraform/20-app/ecs.service.feature-flags.tf
@@ -1,3 +1,10 @@
+locals {
+  flags_sizing = {
+    cpu    = 256
+    memory = 512
+  }
+}
+
 module "ecs_service_feature_flags" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "6.10.0"
@@ -8,8 +15,8 @@ module "ecs_service_feature_flags" {
 
   create_iam_role = true
 
-  cpu        = 256
-  memory     = 512
+  cpu        = local.flags_sizing.cpu
+  memory     = local.flags_sizing.memory
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
@@ -26,8 +33,8 @@ module "ecs_service_feature_flags" {
   container_definitions = {
     api = {
       cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
-      cpu                                    = 256
-      memory                                 = 512
+      cpu                                    = local.flags_sizing.cpu
+      memory                                 = local.flags_sizing.memory
       essential                              = true
       readonlyRootFilesystem                 = false
       image                                  = "unleashorg/unleash-server:5.10.1"

--- a/terraform/20-app/ecs.service.feedback-api.tf
+++ b/terraform/20-app/ecs.service.feedback-api.tf
@@ -1,3 +1,10 @@
+locals {
+  feedback_sizing = {
+    cpu    = local.use_prod_sizing ? 1024 : 512
+    memory = local.use_prod_sizing ? 2048 : 1024
+  }
+}
+
 module "ecs_service_feedback_api" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "6.10.0"
@@ -6,8 +13,8 @@ module "ecs_service_feedback_api" {
   cluster_arn            = module.ecs.cluster_arn
   enable_execute_command = true
 
-  cpu        = local.use_prod_sizing ? 1024 : 512
-  memory     = local.use_prod_sizing ? 2048 : 1024
+  cpu        = local.feedback_sizing.cpu
+  memory     = local.feedback_sizing.memory
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
@@ -32,8 +39,8 @@ module "ecs_service_feedback_api" {
   container_definitions = {
     api = {
       cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
-      cpu                                    = local.use_prod_sizing ? 1024 : 512
-      memory                                 = local.use_prod_sizing ? 2048 : 1024
+      cpu                                    = local.feedback_sizing.cpu
+      memory                                 = local.feedback_sizing.memory
       essential                              = true
       readonlyRootFilesystem                 = true
       image                                  = module.ecr_back_end_ecs.image_uri

--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -1,3 +1,10 @@
+locals {
+  frontend_sizing = {
+    cpu    = local.use_prod_sizing ? 2048 : 512
+    memory = local.use_prod_sizing ? 4096 : 1024
+  }
+}
+
 module "ecs_service_front_end" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "6.10.0"
@@ -6,8 +13,8 @@ module "ecs_service_front_end" {
   cluster_arn            = module.ecs.cluster_arn
   enable_execute_command = true
 
-  cpu        = local.use_prod_sizing ? 2048 : 512
-  memory     = local.use_prod_sizing ? 4096 : 1024
+  cpu        = local.frontend_sizing.cpu
+  memory     = local.frontend_sizing.memory
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
@@ -32,8 +39,8 @@ module "ecs_service_front_end" {
   container_definitions = {
     front-end = {
       cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
-      cpu                                    = local.use_prod_sizing ? 2048 : 512
-      memory                                 = local.use_prod_sizing ? 4096 : 1024
+      cpu                                    = local.frontend_sizing.cpu
+      memory                                 = local.frontend_sizing.memory
       essential                              = true
       readonlyRootFilesystem                 = true
       image                                  = module.ecr_front_end_ecs.image_uri

--- a/terraform/20-app/ecs.service.front-end.tf
+++ b/terraform/20-app/ecs.service.front-end.tf
@@ -1,7 +1,10 @@
 locals {
   frontend_sizing = {
-    cpu    = local.use_prod_sizing ? 2048 : 512
-    memory = local.use_prod_sizing ? 4096 : 1024
+    # provision more resources for prod and the mid-sized envs, but note that the mid-sized envs only have 1 instance
+    # running as per our autoscaling configuration lower down so they aren't as expensive as prod, but they are more
+    # capable than the smaller envs
+    cpu    = local.use_prod_sizing || local.use_mid_sizing ? 2048 : 512
+    memory = local.use_prod_sizing || local.use_mid_sizing ? 4096 : 1024
   }
 }
 

--- a/terraform/20-app/ecs.service.private-api.tf
+++ b/terraform/20-app/ecs.service.private-api.tf
@@ -1,7 +1,10 @@
 locals {
   private_api_sizing = {
-    cpu    = local.use_prod_sizing ? 2048 : 512
-    memory = local.use_prod_sizing ? 4096 : 1024
+    # provision more resources for prod and the mid-sized envs, but note that the mid-sized envs only have 1 instance
+    # running as per our autoscaling configuration lower down so they aren't as expensive as prod, but they are more
+    # capable than the smaller envs
+    cpu    = local.use_prod_sizing || local.use_mid_sizing ? 2048 : 512
+    memory = local.use_prod_sizing || local.use_mid_sizing ? 4096 : 1024
   }
 }
 

--- a/terraform/20-app/ecs.service.private-api.tf
+++ b/terraform/20-app/ecs.service.private-api.tf
@@ -1,3 +1,10 @@
+locals {
+  private_api_sizing = {
+    cpu    = local.use_prod_sizing ? 2048 : 512
+    memory = local.use_prod_sizing ? 4096 : 1024
+  }
+}
+
 module "ecs_service_private_api" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "6.10.0"
@@ -6,8 +13,8 @@ module "ecs_service_private_api" {
   cluster_arn            = module.ecs.cluster_arn
   enable_execute_command = true
 
-  cpu        = local.use_prod_sizing ? 2048 : 512
-  memory     = local.use_prod_sizing ? 4096 : 1024
+  cpu        = local.private_api_sizing.cpu
+  memory     = local.private_api_sizing.memory
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
@@ -34,8 +41,8 @@ module "ecs_service_private_api" {
   container_definitions = {
     api = {
       cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
-      cpu                                    = local.use_prod_sizing ? 2048 : 512
-      memory                                 = local.use_prod_sizing ? 4096 : 1024
+      cpu                                    = local.private_api_sizing.cpu
+      memory                                 = local.private_api_sizing.memory
       essential                              = true
       readonlyRootFilesystem                 = true
       image                                  = module.ecr_back_end_ecs.image_uri

--- a/terraform/20-app/ecs.service.public-api.tf
+++ b/terraform/20-app/ecs.service.public-api.tf
@@ -1,3 +1,10 @@
+locals {
+  public_api_sizing = {
+    cpu    = local.use_prod_sizing ? 1024 : 512
+    memory = local.use_prod_sizing ? 2048 : 1024
+  }
+}
+
 module "ecs_service_public_api" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "6.10.0"
@@ -6,8 +13,8 @@ module "ecs_service_public_api" {
   cluster_arn            = module.ecs.cluster_arn
   enable_execute_command = true
 
-  cpu        = local.use_prod_sizing ? 1024 : 512
-  memory     = local.use_prod_sizing ? 2048 : 1024
+  cpu        = local.public_api_sizing.cpu
+  memory     = local.public_api_sizing.memory
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling       = true
@@ -32,8 +39,8 @@ module "ecs_service_public_api" {
   container_definitions = {
     api = {
       cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
-      cpu                                    = local.use_prod_sizing ? 1024 : 512
-      memory                                 = local.use_prod_sizing ? 2048 : 1024
+      cpu                                    = local.public_api_sizing.cpu
+      memory                                 = local.public_api_sizing.memory
       essential                              = true
       readonlyRootFilesystem                 = true
       image                                  = module.ecr_back_end_ecs.image_uri

--- a/terraform/20-app/ecs.service.utility-worker.tf
+++ b/terraform/20-app/ecs.service.utility-worker.tf
@@ -1,3 +1,10 @@
+locals {
+  utility_worker_sizing = {
+    cpu    = 16384
+    memory = 32768
+  }
+}
+
 module "ecs_service_utility_worker" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "6.10.0"
@@ -6,8 +13,8 @@ module "ecs_service_utility_worker" {
   cluster_arn            = module.ecs.cluster_arn
   enable_execute_command = true
 
-  cpu        = 16384
-  memory     = 32768
+  cpu        = local.utility_worker_sizing.cpu
+  memory     = local.utility_worker_sizing.memory
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling = false
@@ -30,8 +37,8 @@ module "ecs_service_utility_worker" {
   container_definitions = {
     api = {
       cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
-      cpu                                    = 16384
-      memory                                 = 32768
+      cpu                                    = local.utility_worker_sizing.cpu
+      memory                                 = local.utility_worker_sizing.memory
       essential                              = true
       readonlyRootFilesystem                 = true
       image                                  = module.ecr_back_end_ecs.image_uri

--- a/terraform/20-app/ecs.service.worker.tf
+++ b/terraform/20-app/ecs.service.worker.tf
@@ -1,3 +1,10 @@
+locals {
+  worker_sizing = {
+    cpu    = 512
+    memory = 1024
+  }
+}
+
 module "ecs_service_worker" {
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "6.10.0"
@@ -6,8 +13,8 @@ module "ecs_service_worker" {
   cluster_arn            = module.ecs.cluster_arn
   enable_execute_command = true
 
-  cpu        = 512
-  memory     = 1024
+  cpu        = local.worker_sizing.cpu
+  memory     = local.worker_sizing.memory
   subnet_ids = module.vpc.private_subnets
 
   enable_autoscaling = false
@@ -21,8 +28,8 @@ module "ecs_service_worker" {
   container_definitions = {
     api = {
       cloudwatch_log_group_retention_in_days = local.default_log_retention_in_days
-      cpu                                    = 512
-      memory                                 = 1024
+      cpu                                    = local.worker_sizing.cpu
+      memory                                 = local.worker_sizing.memory
       essential                              = true
       readonlyRootFilesystem                 = false
       image                                  = module.ecr_back_end_ecs.image_uri

--- a/terraform/20-app/locals.tf
+++ b/terraform/20-app/locals.tf
@@ -12,6 +12,7 @@ locals {
   use_prod_sizing            = contains([
     "perf", "auth-perf", "pen", "auth-pen", "prod", "auth-prod", "staging",
   ], local.environment)
+  use_mid_sizing             = contains(["dpd"], local.environment)
   # Temporarily switch off auth challenge in staging
   add_password_protection    = false
   auth_enabled               = var.auth_enabled


### PR DESCRIPTION
DPD use the `dpd` env in the `dev` account a fair amount to test things out and need a bit more umph to help it work more quickly. This PR refactors the sizing of all the services into a set of locals, and then introduces a `use_mid_sizing` local (similar to `use_prod_sizing`) to allow specific services to have their resources tweaked in special cases.