### PR TITLE
Default secret version for Entra

### DIFF
--- a/terraform/10-account/secrets-manager.tf
+++ b/terraform/10-account/secrets-manager.tf
@@ -7,3 +7,12 @@ resource "aws_secretsmanager_secret" "entra_api_client_config" {
   name       = "entra-api-client-config"
   kms_key_id = module.kms_secrets.key_id
 }
+
+resource "aws_secretsmanager_secret_version" "entra_api_client_config_value" {
+  secret_id     = aws_secretsmanager_secret.entra_api_client_config.id
+  secret_string = jsonencode({
+    ENTRA_AUDIENCE  = "REPLACE ME"
+    ENTRA_APP_ID    = "REPLACE ME"
+    ENTRA_TENANT_ID = "REPLACE ME"
+  })
+}


### PR DESCRIPTION
With Entra values being consolidated into a single secret, when the ECS tasks reference a specific expected value, we get a failed deployment due to the missing values
While this is reasonable in prod and dev envs etc, the PR checks workflow spins up the entire environment for testing - meaning that the PR checks fail when trying to add the secrets to the task

This PR adds an initial version with temp values, which should allow the checks to pass as values will be present, even if they're invalid
This has been planned and applied against the auth-dev account, secrets manually updated, and then run those commands again to ensure the real values weren't being overwritten