### PR TITLE
Allowing multiple entra app ids

### DIFF
--- a/terraform/10-account/secrets-manager.tf
+++ b/terraform/10-account/secrets-manager.tf
@@ -12,7 +12,7 @@ resource "aws_secretsmanager_secret_version" "entra_api_client_config_value" {
   secret_id     = aws_secretsmanager_secret.entra_api_client_config.id
   secret_string = jsonencode({
     ENTRA_AUDIENCE  = "REPLACE ME"
-    ENTRA_APP_ID    = "REPLACE ME"
+    ENTRA_ALLOWED_APP_IDS    = "REPLACE_ME,REPLACE_ME"
     ENTRA_TENANT_ID = "REPLACE ME"
   })
 }

--- a/terraform/20-app/ecs.service.public-api.tf
+++ b/terraform/20-app/ecs.service.public-api.tf
@@ -112,8 +112,8 @@ module "ecs_service_public_api" {
           valueFrom = "${data.aws_secretsmanager_secret.entra_api_client_config.arn}:ENTRA_TENANT_ID::"
         },
         {
-          name      = "ENTRA_APP_ID",
-          valueFrom = "${data.aws_secretsmanager_secret.entra_api_client_config.arn}:ENTRA_APP_ID::"
+          name      = "ENTRA_ALLOWED_APP_IDS",
+          valueFrom = "${data.aws_secretsmanager_secret.entra_api_client_config.arn}:ENTRA_ALLOWED_APP_IDS::"
         },
         {
           name      = "ENTRA_AUDIENCE",


### PR DESCRIPTION
Updates the secrets manager config and the public API secrets to use a value for multiple Entra app ids instead of a single allowed app id