### PR TITLE
Updating well known branch names for staging

### DIFF
--- a/.github/actions/well-known-environment-name/action.yml
+++ b/.github/actions/well-known-environment-name/action.yml
@@ -17,5 +17,5 @@ runs:
         echo "IS_ACCOUNT_LAYER_BRANCH=$is_account_layer_branch" >> $GITHUB_ENV
       env:
         branch: ${{ inputs.branch }}
-        is_account_layer_branch: ${{ contains(fromJSON('["env/dev/dev", "env/auth-dev/auth-dev", "env/test/test", "env/auth-test/auth-test", "env/uat/uat", "env/auth-uat/auth-uat", "env/auth-prod/auth-prod"]'), inputs.branch) }}
+        is_account_layer_branch: ${{ contains(fromJSON('["env/dev/dev", "env/auth-dev/auth-dev", "env/test/test", "env/auth-test/auth-test", "env/uat/staging", "env/auth-uat/auth-uat", "env/auth-prod/auth-prod"]'), inputs.branch) }}
       shell: bash


### PR DESCRIPTION
Staging hasn't been deploying the account layer terraform for a long time (checking PRs months ago shows the changes aren't present)
Appears to be a mismatch between the `branch` input for staging in the production workflow, and the `is_account_layer_branch` env variable in `well-known-environment-name`

This PR updates that env variable from `env/uat/uat` to `env/uat/staging` to bring it in line with the production workflows input variable