### PR TITLE
Remove cognito_jwt_auth_header now that api is using jwt_auth_header

### DIFF
--- a/terraform/20-app/ecs.service.private-api.tf
+++ b/terraform/20-app/ecs.service.private-api.tf
@@ -108,10 +108,6 @@ module "ecs_service_private_api" {
           value = local.region
         },
         {
-          name  = "COGNITO_JWT_AUTH_HEADER"
-          value = "HTTP_X_UHD_AUTH"
-        },
-        {
           name  = "JWT_AUTH_HEADER"
           value = "HTTP_X_UHD_AUTH"
         },


### PR DESCRIPTION
Remove unneeded variable - it is now renamed to just `JWT_AUTH_HEADER` but the change was done in 2 steps to avoid any issues with the timing of merging in api and infra PRs