### PR TITLE
Add resource discovery permissions to ObservabilityReadOnly policy

### DIFF
--- a/terraform/10-account/iam.observability-role.tf
+++ b/terraform/10-account/iam.observability-role.tf
@@ -50,6 +50,15 @@ module "iam_cloudwatch_readonly_policy" {
           "logs:StopQuery"
         ],
         Resource = "*"
+      },
+      {
+        Sid = "ResourceDiscovery",
+        Effect = "Allow",
+        Action = [
+          "tag:GetResources",
+          "iam:ListAccountAliases"
+        ],
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
YACE (CloudWatch exporter) requires tag:GetResources to discover ECS and ALB resources via the Resource Groups Tagging API before querying CloudWatch metrics. Without it cross-account scraping fails at the discovery step. iam:ListAccountAliases added to suppress a non-critical YACE warning.