### PR TITLE
Add cloudwatch:DescribeAlarms to ObservabilityReadOnly policy

### DIFF
--- a/terraform/10-account/iam.observability-role.tf
+++ b/terraform/10-account/iam.observability-role.tf
@@ -33,7 +33,8 @@ module "iam_cloudwatch_readonly_policy" {
         Action =  [
           "cloudwatch:GetMetricStatistics",
           "cloudwatch:GetMetricData",
-          "cloudwatch:ListMetrics"
+          "cloudwatch:ListMetrics",
+          "cloudwatch:DescribeAlarms"
         ],
         Resource = "*"
       },


### PR DESCRIPTION
Required for cross-account alarm state discovery — surfaces CloudWatch alarm states per workload service into the observability platform.