### PR TITLE
Allow Grafana workspace role to assume Observability cross-account role

### DIFF
--- a/terraform/10-account/iam.observability-role.tf
+++ b/terraform/10-account/iam.observability-role.tf
@@ -12,7 +12,8 @@ module "iam_observability_role" {
   ]
 
   trusted_role_arns = compact([
-    "arn:aws:iam::943339978990:role/observability-bridge-role"
+    "arn:aws:iam::943339978990:role/observability-bridge-role",
+    "arn:aws:iam::943339978990:role/managed-grafana-workspace-role"
   ])
 }
 


### PR DESCRIPTION
Add managed-grafana-workspace-role to Observability role trust policy

AMG uses managed-grafana-workspace-role when assuming cross-account roles for datasources. The existing trust only covered observability-bridge-role (YACE metrics), so Grafana couldn't query CloudWatch Logs. This adds the workspace role as a second trusted principal.  No other permissions changed.