### PR TITLE
chore: add ignore tags block for centralised tags we don't manage

### DIFF
--- a/terraform/10-account/main.tf
+++ b/terraform/10-account/main.tf
@@ -10,6 +10,10 @@ provider "aws" {
       env          = terraform.workspace
     }
   }
+
+  ignore_tags {
+    key_prefixes = ["lz:"]
+  }
 }
 
 provider "aws" {
@@ -17,6 +21,9 @@ provider "aws" {
   region = "us-east-1"
   assume_role {
     role_arn = "arn:aws:iam::${var.assume_account_id}:role/${var.assume_role_name}"
+  }
+  ignore_tags {
+    key_prefixes = ["lz:"]
   }
 }
 

--- a/terraform/20-app/main.tf
+++ b/terraform/20-app/main.tf
@@ -10,6 +10,10 @@ provider "aws" {
       env          = terraform.workspace
     }
   }
+
+  ignore_tags {
+    key_prefixes = ["lz:"]
+  }
 }
 
 provider "aws" {
@@ -17,6 +21,10 @@ provider "aws" {
   region = "us-east-1"
   assume_role {
     role_arn = "arn:aws:iam::${var.assume_account_id}:role/${var.assume_role_name}"
+  }
+
+  ignore_tags {
+    key_prefixes = ["lz:"]
   }
 }
 


### PR DESCRIPTION
The central devops team are adding tags to our resources to track them better but they will not appear in our IaC, hence we need to ignore them to avoid drift.